### PR TITLE
minor: set default cursor for div.body/div.bc

### DIFF
--- a/themes/mongodb/static/mongodb-docs.css_t
+++ b/themes/mongodb/static/mongodb-docs.css_t
@@ -883,6 +883,7 @@ div.body div.bc {
     padding-top: .6em;
     margin-left: 1.5em;
     background:white;
+    cursor: default;
 }
 div.body div.bc li.jr { float: right; display:none; }
 div.body div.bc ul { padding:0; margin:0 }


### PR DESCRIPTION
Noticed the cursor flashing when I rolled over a breadcrumb (switched from pointer to insertion to default). Most of the content has cursor: default, don't know why I hadn't set it on div.body. Kind of stupid that in 2013 we still have to write "cursor:default" in CSS but…there you go.
