### PR TITLE
Fix check for parallel build support in Sphinx

### DIFF
--- a/utils/sphinx/config.py
+++ b/utils/sphinx/config.py
@@ -12,12 +12,7 @@ def get_sconf(conf):
                                                      conf.paths.builddata))
 
 def is_parallel_sphinx(version):
-    if version in [ '1.2b1-xgen', '1.2b2', '1.2b3', '1.2', '1.2.1']:
-        return True
-    elif [ int(n) for n in version.split('.') ][1] >= 2:
-        return True
-
-    return False
+    return version >= '1.2'
 
 def get_sphinx_args(sconf, conf):
     o = []


### PR DESCRIPTION
The previous check was failing with any build version containing non-numeric parts, eg. `1.3a1`.  This should work until Sphinx' 10.x release (which, given 1.0 took three years and we're not yet out of 1.x, seems unlikely in the near future.)
