### PR TITLE
theme: fix invisible footnote element

### DIFF
--- a/themes/mongodb/static/bootstrap-custom.css
+++ b/themes/mongodb/static/bootstrap-custom.css
@@ -230,7 +230,7 @@ table {
   .dropup > .btn > .caret {
     border-top-color: #000 !important;
   }
-  .label {
+  .bootstrap-label {
     border: 1px solid #000;
   }
   .table {
@@ -4171,7 +4171,7 @@ textarea.input-group-sm > .input-group-btn > .btn {
   background-color: #ffffff;
   cursor: not-allowed;
 }
-.label {
+.bootstrap-label {
   display: inline;
   padding: .2em .6em .3em;
   font-size: 75%;
@@ -4183,13 +4183,13 @@ textarea.input-group-sm > .input-group-btn > .btn {
   vertical-align: baseline;
   border-radius: .25em;
 }
-.label[href]:hover,
-.label[href]:focus {
+.bootstrap-label[href]:hover,
+.bootstrap-label[href]:focus {
   color: #ffffff;
   text-decoration: none;
   cursor: pointer;
 }
-.label:empty {
+.bootstrap-label:empty {
   display: none;
 }
 .label-default {


### PR DESCRIPTION
Bootstrap's ["label" CSS class](http://www.tutorialspoint.com/bootstrap/bootstrap_labels.htm) is giving extra meaning to the
docutils "label" class, causing our footnote anchors to be made
invisible when there's more than one backref. Instead of making
label's meaning context-sensitive or trying to trick docutils into
applying an additional "label-info" class (which really gives us no
additional benefit and may not be possible anyway), I chose to just
rename Bootstrap's version of "label" to "bootstrap-label".

To the best of my knowledge we aren't using Bootstrap's label for
anything, but if we are, it's a trivial update.
