### PR TITLE
DOCS-4019: Add navigational hints

### DIFF
--- a/themes/mongodb/static/mongodb-docs.css_t
+++ b/themes/mongodb/static/mongodb-docs.css_t
@@ -1598,3 +1598,14 @@ h4.modal-title {
 .saving-copy, .redirect-copy {
     height: 100px;
 }
+
+.expand-icon {
+    vertical-align: 1.5px;
+    font-size: 0.6em;
+    width: 0.5em;
+    display: inline-block;
+}
+
+li.current > a > .fa.expand-icon:before {
+    content: ""; /* fa-minus */
+}

--- a/themes/mongodb/static/navbar.js
+++ b/themes/mongodb/static/navbar.js
@@ -170,4 +170,17 @@ $(function() {
         }
     });
 
+    /* Add expand icons to indicate what's expandable and what's a link. This
+       is necessary when (1) we're at a leaf node, or (2) the menu triggers
+       a page load. */
+    $('.sphinxsidebarwrapper > ul ul a.reference').prepend(function(index) {
+        var expandElement = $('<span class="expand-icon"></span>');
+        var self = $(this)
+
+        if(!isLeafNode(self) && !requiresPageload(self)) {
+            expandElement.addClass('fa fa-plus');
+        }
+
+        return expandElement;
+    });
 });


### PR DESCRIPTION
Tested on:
- Firefox 32 (Hard-coded 1.5px offset necessary because of bug 727125)
- Chrome 37
- Safari 7

No-JavaScript story remains unchanged: no navbar.

@rawfalafel Could you review this?
