### PR TITLE
Introduce 'giza http' command.

### DIFF
--- a/giza/giza/cmdline.py
+++ b/giza/giza/cmdline.py
@@ -26,6 +26,7 @@ import giza.operations.configuration
 import giza.operations.deploy
 import giza.operations.generate
 import giza.operations.git
+import giza.operations.http_serve
 import giza.operations.includes
 import giza.operations.make
 import giza.operations.packaging
@@ -43,7 +44,8 @@ commands = {
         giza.operations.make.main,
         giza.operations.quickstart.make_project,
         giza.operations.sphinx.main,
-        giza.operations.deploy.twofa_code
+        giza.operations.deploy.twofa_code,
+        giza.operations.http_serve.start,
     ],
     'git': [
         giza.operations.git.apply_patch,

--- a/giza/giza/config/runtime.py
+++ b/giza/giza/config/runtime.py
@@ -190,7 +190,7 @@ class RuntimeStateConfig(RuntimeStateConfigurationBase):
                          'git_sign_patch', 'serial_sphinx', 'package_path',
                          'clean_generated', 'include_mask', 'push_targets',
                          'dry_run', 't_corpora_config', 't_translate_config',
-                         't_output_file', 't_source', 't_target']
+                         't_output_file', 't_source', 't_target', 'port']
 
     def __init__(self, obj=None):
         super(RuntimeStateConfig, self).__init__(obj)

--- a/giza/giza/operations/http_serve.py
+++ b/giza/giza/operations/http_serve.py
@@ -1,0 +1,50 @@
+import sys
+import os.path
+
+if sys.version_info[0] == 2:
+    import SocketServer as socket_server
+    import SimpleHTTPServer as http_server
+else:
+    import socketserver as socket_server
+    import http.server as http_server
+
+import logging
+logger = logging.getLogger('giza.operations.http')
+
+import argh
+from giza.config.helper import fetch_config
+
+
+class RequestHandler(http_server.SimpleHTTPRequestHandler):
+    """Request handler wrapper that hosts files rooted at a particular
+       directory."""
+    def translate_path(self, path):
+        """Map a request into the build/ directory."""
+        path = os.path.relpath(path, '/')
+        return os.path.join(self.root, path)
+
+    def log_message(self, fmt, *args):
+        """Pass this server event into the operation logger."""
+        logger.info(fmt % args)
+
+
+@argh.arg('--port', '-p', default=8090, dest='port')
+@argh.arg('--builder', '-b', nargs='*', default='publish')
+@argh.named('http')
+def start(args):
+    """Start an HTTP server rooted in the build directory."""
+    config = fetch_config(args)
+
+
+    if config.runstate.is_publish_target():
+        root = config.paths.public_site_output
+    else:
+        root = os.path.join(config.paths.projectroot,
+                            config.paths.branch_output,
+                            args.builder[0])
+
+    RequestHandler.root = root
+
+    httpd = socket_server.TCPServer(('', config.runstate.port), RequestHandler)
+    logger.info('Hosting {0} on port {1}'.format(root, config.runstate.port))
+    httpd.serve_forever()


### PR DESCRIPTION
Resources are now broken when accessed via file:// as part of the protocol
agnosticism changes. You must now run 'giza http' and view the generated documentation
at localhost:8090 or whatever port you choose.
