### PR TITLE
WRITING-1270: Harmonize link schemas to https://

### DIFF
--- a/giza/docs/conf.py
+++ b/giza/docs/conf.py
@@ -56,12 +56,12 @@ rst_epilog = '\n'.join([
 pygments_style = 'sphinx'
 
 extlinks = {
-    'hardlink' : ( 'http://docs.mongodb.org/{0}/%s'.format(conf.git.branches.current), ''),
+    'hardlink' : ( 'https://docs.mongodb.org/{0}/%s'.format(conf.git.branches.current), ''),
     'issue': ('https://jira.mongodb.org/browse/%s', '' ),
     'api': ('http://api.mongodb.org/%s', ''),
-    'manual': ('http://docs.mongodb.org/manual%s', ''),
-    'ecosystem': ('http://docs.mongodb.org/ecosystem%s', ''),
-    'meta-driver': ('http://docs.mongodb.org/meta-driver/latest%s', ''),
+    'manual': ('https://docs.mongodb.org/manual%s', ''),
+    'ecosystem': ('https://docs.mongodb.org/ecosystem%s', ''),
+    'meta-driver': ('https://docs.mongodb.org/meta-driver/latest%s', ''),
     'mms': ('https://mms.mongodb.com/help%s', ''),
     'mms-hosted': ('https://mms.mongodb.org/help-hosted%s', ''),
     'about': ('http://www.mongodb.org/about%s', '')

--- a/themes/about/page.html
+++ b/themes/about/page.html
@@ -16,9 +16,9 @@
 {%- block language_selector %}{%- endblock -%}
 
 {%- block subnav %}
-   <a href="http://docs.mongodb.org/manual">Manual</a>
-   <a href="http://docs.mongodb.org/ecosystem">Ecosystem</a>
-   <a href="http://www.mongodb.org/downloads">Downloads</a>
-   <a href="http://www.mongodb.org/get-involved">Community</a>
+   <a href="https://docs.mongodb.org/manual">Manual</a>
+   <a href="https://docs.mongodb.org/ecosystem">Ecosystem</a>
+   <a href="https://www.mongodb.org/downloads">Downloads</a>
+   <a href="https://www.mongodb.org/get-involved">Community</a>
    <a href="http://blog.mongodb.org">Blog</a>
 {% endblock %}

--- a/themes/ecosystem/page.html
+++ b/themes/ecosystem/page.html
@@ -5,7 +5,7 @@
 {%- block version_selector %} {% endblock %}
 
 {%- block subnav %}
-   <a href="http://docs.mongodb.org/manual/">Manual</a>
+   <a href="https://docs.mongodb.org/manual/">Manual</a>
    <a href="https://university.mongodb.com/">Learn</a>
    <a href="http://www.mongodb.org/downloads">Downloads</a>
    <a href="http://www.mongodb.org/get-involved">Community</a>

--- a/themes/mongodb/analytics.html
+++ b/themes/mongodb/analytics.html
@@ -1,4 +1,4 @@
 <script type="text/javascript">
-document.write(unescape("%3Cscript src='" + document.location.protocol + "//munchkin.marketo.net/munchkin.js' type='text/javascript'%3E%3C/script%3E"));
+document.write(unescape("%3Cscript src='" + document.location.protocol + "https://munchkin.marketo.net/munchkin.js' type='text/javascript'%3E%3C/script%3E"));
 </script>
 <script>try { mktoMunchkin("017-HGS-593"); } catch(e) {}</script>

--- a/themes/mongodb/layout.html
+++ b/themes/mongodb/layout.html
@@ -101,12 +101,12 @@
 {%- endif %}
 
 <head>
-  <link href='//fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css'>
   {%- block htmltitle %}
     <title>{{ title|striptags|e }}</title>
   {%- endblock -%}
 
-  <link rel="shortcut icon" href="//media.mongodb.org/favicon.ico" />
+  <link rel="shortcut icon" href="https://media.mongodb.org/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="Content-Type" content="text/html; charset={{ encoding }}" />
   <meta name="robots" content="index" />
@@ -122,7 +122,7 @@
     {{ script() }}
 
     {%- block googlecse_opensearch %}
-      <link rel="search" type="application/opensearchdescription+xml" href="http://docs.mongodb.org/osd.xml" title="MongoDB Help"/>
+      <link rel="search" type="application/opensearchdescription+xml" href="https://docs.mongodb.org/osd.xml" title="MongoDB Help"/>
     {%- endblock -%}
 
     {%- if favicon %}
@@ -171,7 +171,7 @@
 <body>
   {%- block googletagmanager %}
   <!-- Google Tag Manager -->
-  <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-JQHP"
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-JQHP"
                     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
      {'gtm.start': new Date().getTime(),event:'gtm.js'}
@@ -188,14 +188,14 @@
         <a class="fa fa-bars expand-toc-icon pull-left" href="#"></a>
         {%- block header_logo %}
            <div class="logo pull-left">
-             <a href="http://www.mongodb.org/">
-               <img src="//media.mongodb.org/logo-mongodb-header.png", alt="MongoDB.org" />
+             <a href="https://www.mongodb.org/">
+               <img src="https://media.mongodb.org/logo-mongodb-header.png", alt="MongoDB.org" />
              </a>
            </div>
         {% endblock %}
         <div>
           {%- block searchbox %}
-          <div class="search-db narrow pull-right"><gcse:searchbox-only resultsUrl="http://docs.mongodb.org/manual/search/" queryParameterName="query"></gcse:searchbox-only></div>
+          <div class="search-db narrow pull-right"><gcse:searchbox-only resultsUrl="https://docs.mongodb.org/manual/search/" queryParameterName="query"></gcse:searchbox-only></div>
           {% endblock %}
           <div class="nav-items pull-right">
             {%- block subnav %}
@@ -248,7 +248,7 @@
                 <label>{{ _('Langauges') }}</label>
                 <select class="language-selector pull-right">
                   {%- for lc,lang in theme_translations -%}
-                      <option data-path="http://{{lc}}.docs.mongodb.org/{{ page_url }}">
+                      <option data-path="https://{{lc}}.docs.mongodb.org/{{ page_url }}">
                         {{lang}}
                       </option>
                   {% endfor -%}
@@ -309,7 +309,7 @@
                 {%- block footer %}
                   <div class="footer">
                     <div class="copyright">
-                      <p>Copyright &copy; {{copyright}} <a class="smalltext" href="http://www.mongodb.com">MongoDB, Inc</a>. Licensed under <a href="http://creativecommons.org/licenses/by-nc-sa/3.0/ ">Creative Commons</a>. MongoDB, Mongo, and the leaf logo are registered trademarks of MongoDB, Inc.</p>
+                      <p>Copyright &copy; {{copyright}} <a class="smalltext" href="https://www.mongodb.com">MongoDB, Inc</a>. Licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/ ">Creative Commons</a>. MongoDB, Mongo, and the leaf logo are registered trademarks of MongoDB, Inc.</p>
                     </div>
                   </div>
                 {%- endblock %}
@@ -339,7 +339,7 @@
         {%- block social %}
            <div class="social">
              <a class="twitter-icon" href="https://twitter.com/mongodbinc"><i class="fa fa-twitter-square"></i></a>
-             <a class="youtube-icon" href="http://www.youtube.com/user/MongoDB"><i class="fa fa-youtube-square"></i></a>
+             <a class="youtube-icon" href="https://www.youtube.com/user/MongoDB"><i class="fa fa-youtube-square"></i></a>
              <a class="facebook-icon" href="https://www.facebook.com/mongodb"><i class="fa fa-facebook-square"></i></a>
              <a class="gplus-icon" href="https://plus.google.com/u/1/101024085748034940765/posts?cfem=1"><i class="fa fa-google-plus-square"></i></a>
            </div>

--- a/themes/mongodb/static/mongodb-docs.css_t
+++ b/themes/mongodb/static/mongodb-docs.css_t
@@ -10,7 +10,7 @@
  */
 @import url("basic.css");
 
-@import url(//fonts.googleapis.com/css?family=Source+Code+Pro:300,500,700);
+@import url(https://fonts.googleapis.com/css?family=Source+Code+Pro:300,500,700);
 
 /* OS X hides scroll bars, which makes some of our code boxes confusing. */
 
@@ -39,7 +39,7 @@
     height: 100%;
     z-index: 2000;
     opacity: 0.5;
-    background: url(//media.mongodb.org/24px-baseline-overlay.png) 0 0 repeat;
+    background: url(https://media.mongodb.org/24px-baseline-overlay.png) 0 0 repeat;
 }
 
 body {
@@ -314,7 +314,7 @@ div.related li.right {
 #main-db {
     padding-top: 2.5em;
     padding-bottom: 2em;
-    background-image: url(http://media.mongodb.org/back-body.png);
+    background-image: url(https://media.mongodb.org/back-body.png);
     background-repeat: repeat-x;
 }
 
@@ -329,7 +329,7 @@ div#top-right ul#header-menu-bar {
     margin-top: 0;
     padding-left: 20px;
     height: 38px;
-    background-image: url(http://media.mongodb.org/trans-user-left.png);
+    background-image: url(https://media.mongodb.org/trans-user-left.png);
     background-repeat: no-repeat;
 }
 
@@ -340,7 +340,7 @@ div#top-right div.user-right  {
     margin: 0;
     padding: 0 20px 0 0;
     font-size: 10pt;
-    background-image: url(http://media.mongodb.org/trans-user-right.png);
+    background-image: url(https://media.mongodb.org/trans-user-right.png);
     background-position: top right;
     background-repeat: no-repeat;
 }
@@ -349,7 +349,7 @@ div#top-right div.user-right li.normal {
     float: left;
     padding: 8px 1em 0 0;
     height: 38px;
-    background-image: url(http://media.mongodb.org/trans-user-back.png);
+    background-image: url(https://media.mongodb.org/trans-user-back.png);
     background-repeat: repeat-x;
     list-style-type: none;
     font-size: 10pt;
@@ -438,14 +438,14 @@ ul.home-nav li.docs { width: 276px; }
 
 ul.home-nav li.docs a, ul.home-nav li.docs a:visited {
     float: left;
-    background: url(http://www.mongodb.org/static/images/home_nav.png) -11px -63px;
+    background: url(https://www.mongodb.org/static/images/home_nav.png) -11px -63px;
     width: 209px;
     height: 54px;
 }
 
 ul.home-nav li.docs a:hover {
     float: left;
-    background: url(http://www.mongodb.org/static/images/home_nav.png) -11px 0;
+    background: url(https://www.mongodb.org/static/images/home_nav.png) -11px 0;
     width: 209px;
     height: 54px;
 }
@@ -454,14 +454,14 @@ ul.home-nav li.try { width: 238px; }
 
 ul.home-nav li.try a, ul.home-nav li.try a:visited {
     float: left;
-    background: url(http://www.mongodb.org/static/images/home_nav.png) -274px -63px;
+    background: url(https://www.mongodb.org/static/images/home_nav.png) -274px -63px;
     width: 176px;
     height: 54px;
 }
 
 ul.home-nav li.try a:hover {
     float: left;
-    background: url(http://www.mongodb.org/static/images/home_nav.png) -274px 0;
+    background: url(https://www.mongodb.org/static/images/home_nav.png) -274px 0;
     width: 176px;
     height: 54px;
 }
@@ -470,14 +470,14 @@ ul.home-nav li.downloads { width: 245px; }
 
 ul.home-nav li.downloads a, ul.home-nav li.downloads a:visited {
     float: left;
-    background: url(http://www.mongodb.org/static/images/home_nav.png) -497px -63px;
+    background: url(https://www.mongodb.org/static/images/home_nav.png) -497px -63px;
     width: 185px;
     height: 54px;
 }
 
 ul.home-nav li.downloads a:hover {
     float: left;
-    background: url(http://www.mongodb.org/static/images/home_nav.png) -497px 0;
+    background: url(https://www.mongodb.org/static/images/home_nav.png) -497px 0;
     width: 185px;
     height: 54px;
 }
@@ -488,14 +488,14 @@ ul.home-nav li.drivers {
 
 ul.home-nav li.drivers a, ul.home-nav li.drivers a:visited {
     float: left;
-    background: url(http://www.mongodb.org/static/images/home_nav.png) right -63px no-repeat;
+    background: url(https://www.mongodb.org/static/images/home_nav.png) right -63px no-repeat;
     width: 194px;
     height: 54px;
 }
 
 ul.home-nav li.drivers a:hover {
     float: left;
-    background: url(http://www.mongodb.org/static/images/home_nav.png) right 0 no-repeat;
+    background: url(https://www.mongodb.org/static/images/home_nav.png) right 0 no-repeat;
     width: 194px;
     height: 54px;
 }
@@ -551,7 +551,7 @@ div.section > h1 + dl.projection > dt {display: none;}
 }
 
 div.highlight pre {
-    background: #f5f6f7 url(http://media.mongodb.org.s3.amazonaws.com/code-block-bg.png) 0 0 repeat;
+    background: #f5f6f7 url(https://media.mongodb.org/code-block-bg.png) 0 0 repeat;
     border-radius: 0;
     border: none;
     border-left: 5px solid #494747;
@@ -566,7 +566,7 @@ div.highlight pre {
 @media (-webkit-min-device-pixel-ratio: 2),
 (min-resolution: 192dpi) {
     div.highlight pre {
-        background: #f5f6f7 url(http://media.mongodb.org.s3.amazonaws.com/code-block-bg@2x.png) 0 0 repeat;
+        background: #f5f6f7 url(https://media.mongodb.org/code-block-bg@2x.png) 0 0 repeat;
         background-size: 12px 12px;
     }
 }

--- a/themes/mongodb/translations.html
+++ b/themes/mongodb/translations.html
@@ -17,6 +17,6 @@
 <h3><a href="{{ pathto('/meta/translation') }}">Translations</a></h3>
 <ul class="translation-menu">
 {%- for lc,lang in theme_translations -%}
-    <li><a href="http://{{lc}}.docs.mongodb.org/{{ page_url }}" rel="nofollow" hreflang="{{lc}}" title="{{html_short_title}} in {{lang}}">{{lang}}</a></li>
+    <li><a href="https://{{lc}}.docs.mongodb.org/{{ page_url }}" rel="nofollow" hreflang="{{lc}}" title="{{html_short_title}} in {{lang}}">{{lang}}</a></li>
 {% endfor -%}
 </ul>

--- a/themes/primer/layout.html
+++ b/themes/primer/layout.html
@@ -106,7 +106,7 @@
     <title>{{ title|striptags|e }}</title>
   {%- endblock -%}
 
-  <link rel="shortcut icon" href="//media.mongodb.org/favicon.ico" />
+  <link rel="shortcut icon" href="https://media.mongodb.org/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="Content-Type" content="text/html; charset={{ encoding }}" />
   <meta name="robots" content="index" />
@@ -122,7 +122,7 @@
     {{ script() }}
 
     {%- block googlecse_opensearch %}
-      <link rel="search" type="application/opensearchdescription+xml" href="http://docs.mongodb.org/osd.xml" title="MongoDB Help"/>
+      <link rel="search" type="application/opensearchdescription+xml" href="https://docs.mongodb.org/osd.xml" title="MongoDB Help"/>
     {%- endblock -%}
 
     {%- if favicon %}
@@ -171,7 +171,7 @@
 <body>
   {%- block googletagmanager %}
   <!-- Google Tag Manager -->
-  <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-JQHP"
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-JQHP"
                     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
      {'gtm.start': new Date().getTime(),event:'gtm.js'}
@@ -188,14 +188,14 @@
         <a class="fa fa-bars expand-toc-icon pull-left" href="#"></a>
         {%- block header_logo %}
            <div class="logo pull-left">
-             <a href="http://www.mongodb.org/">
-               <img src="//media.mongodb.org/logo-mongodb-header.png", alt="MongoDB.org" />
+             <a href="https://www.mongodb.org/">
+               <img src="https://media.mongodb.org/logo-mongodb-header.png", alt="MongoDB.org" />
              </a>
            </div>
         {% endblock %}
         <div>
           {%- block searchbox %}
-          <div class="search-db narrow pull-right"><gcse:searchbox-only resultsUrl="http://docs.mongodb.org/manual/search/" queryParameterName="query"></gcse:searchbox-only></div>
+          <div class="search-db narrow pull-right"><gcse:searchbox-only resultsUrl="https://docs.mongodb.org/manual/search/" queryParameterName="query"></gcse:searchbox-only></div>
           {% endblock %}
           <div class="nav-items pull-right">
             {%- block subnav %}
@@ -248,7 +248,7 @@
                 <label>{{ _('Langauges') }}</label>
                 <select class="language-selector pull-right">
                   {%- for lc,lang in theme_translations -%}
-                      <option data-path="http://{{lc}}.docs.mongodb.org/{{ page_url }}">
+                      <option data-path="https://{{lc}}.docs.mongodb.org/{{ page_url }}">
                         {{lang}}
                       </option>
                   {% endfor -%}
@@ -291,7 +291,7 @@
                 {%- block footer %}
                   <div class="footer">
                     <div class="copyright">
-                      <p>Copyright &copy; {{copyright}} <a class="smalltext" href="http://www.mongodb.com">MongoDB, Inc</a>. Licensed under <a href="http://creativecommons.org/licenses/by-nc-sa/3.0/ ">Creative Commons</a>. MongoDB, Mongo, and the leaf logo are registered trademarks of MongoDB, Inc.</p>
+                      <p>Copyright &copy; {{copyright}} <a class="smalltext" href="https://www.mongodb.com">MongoDB, Inc</a>. Licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/ ">Creative Commons</a>. MongoDB, Mongo, and the leaf logo are registered trademarks of MongoDB, Inc.</p>
                     </div>
                   </div>
                 {%- endblock %}
@@ -321,7 +321,7 @@
         {%- block social %}
            <div class="social">
              <a class="twitter-icon" href="https://twitter.com/mongodbinc"><i class="fa fa-twitter-square"></i></a>
-             <a class="youtube-icon" href="http://www.youtube.com/user/MongoDB"><i class="fa fa-youtube-square"></i></a>
+             <a class="youtube-icon" href="https://www.youtube.com/user/MongoDB"><i class="fa fa-youtube-square"></i></a>
              <a class="facebook-icon" href="https://www.facebook.com/mongodb"><i class="fa fa-facebook-square"></i></a>
              <a class="gplus-icon" href="https://plus.google.com/u/1/101024085748034940765/posts?cfem=1"><i class="fa fa-google-plus-square"></i></a>
            </div>


### PR DESCRIPTION
This has three effects:
* Local renders look nicer, because static resources point to our media servers instead of broken file:// paths.
* Fewer HTTPS warnings. Not a serious concern for us, but it's nice to avoid loading unencrypted resources from an HTTPS page.
* Internal style is more consistent.  Not that this makes much of a dent in that...