### PR TITLE
Make stage and test work in project subdirectories

### DIFF
--- a/giza/giza/cmdline.py
+++ b/giza/giza/cmdline.py
@@ -47,7 +47,7 @@ commands = {
         giza.operations.sphinx_cmds.main,
         giza.operations.deploy.twofa_code,
         giza.operations.http_serve.start,
-        giza.operations.stage.start,
+        giza.operations.stage.main,
         giza.operations.configuration.report_version,
         giza.operations.make.main,
         giza.operations.test.integration_main

--- a/giza/giza/config/main.py
+++ b/giza/giza/config/main.py
@@ -132,7 +132,7 @@ class Configuration(ConfigurationBase):
 
     @deploy.setter
     def deploy(self, value):
-        fn = os.path.join(self.paths.global_config, 'deploy.yaml')
+        fn = os.path.join(self.paths.projectroot, self.paths.global_config, 'deploy.yaml')
         if os.path.exists(fn):
             self.state['deploy'] = DeployConfig(fn)
         else:
@@ -146,7 +146,7 @@ class Configuration(ConfigurationBase):
 
     @test.setter
     def test(self, value):
-        fn = os.path.join(self.paths.global_config, 'test-matrix.yaml')
+        fn = os.path.join(self.paths.projectroot, self.paths.global_config, 'test-matrix.yaml')
         if os.path.exists(fn):
             self.state['test'] = TestConfig(fn)
         else:

--- a/giza/giza/config/paths.py
+++ b/giza/giza/config/paths.py
@@ -203,3 +203,9 @@ class PathsConfig(RecursiveConfigurationBase):
 
             self.state['htaccess'] = p
             return self.state['htaccess']
+
+    @property
+    def file_changes_database(self):
+        """Returns a path to the database containing output path mtimes and
+           hashes to back FileCollector."""
+        return os.path.join(self.projectroot, self.output, 'stage-cache.db')


### PR DESCRIPTION
``Configuration.deploy`` and ``Configuration.test`` were relative, causing them to be invalid whenever they were accessed while underneath the project root.

``giza stage`` only needed to fix the former, but I took the liberty of applying the same fix to the latter.