### PR TITLE
adds published branches for ecosystem to avoid legacy branch error

### DIFF
--- a/data/ecosystem-published-branches.yaml
+++ b/data/ecosystem-published-branches.yaml
@@ -1,0 +1,13 @@
+version:
+  published:
+    - 'master'
+  stable: 'master'
+  upcoming: null
+git:
+  branches:
+    manual: 'master'
+    published:
+      - 'master'
+      # the branches/published list **must** be ordered from most to
+      # least recent release.
+...


### PR DESCRIPTION
I think this is the minimum viable published branches. I _don't think_ it'll add a version flipper, but am not entirely confident on that front.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs-tools/108)
<!-- Reviewable:end -->
