### PR TITLE
add OM 3.4 to the list of published branches

### DIFF
--- a/data/mms-published-branches.yaml
+++ b/data/mms-published-branches.yaml
@@ -1,5 +1,6 @@
 version:
   published:
+    - '3.4'
     - '2.1-pre'
     - '2.0'
     - '1.8'


### PR DESCRIPTION
@kay-kim @schmalliso @i80and I'm starting to create new Ops Manager 3.4 pages that will require redirects in the pre-3.4 documentation. For example:

```---
from: /reference/api/server-pools
to: /api
type: redirect
outputs:
  - before-v3.4
edition: onprem
```
 
When I do this, my local builds of the documentation fail, unless I also add `3.4` in `data/mms-published-branches.yaml`.

Would making this change in `docs-tools` master have any adverse effects on our published docs?