### PR TITLE
DOCS-9100: adds support for options that differ only by case

### DIFF
--- a/giza/giza/content/options/models.py
+++ b/giza/giza/content/options/models.py
@@ -25,7 +25,8 @@ if sys.version_info >= (3, 0):
 
 class OptionData(InheritableContentBase):
     _option_registry = ['pre', 'post', 'final', 'ref', 'content', 'edition',
-                        'description', 'name', 'args', 'aliases', 'default', 'type']
+                        'description', 'name', 'args', 'aliases', 'default', 
+                        'type', 'filename']
 
     @property
     def source(self):
@@ -81,6 +82,18 @@ class OptionData(InheritableContentBase):
             self.state['command'] = value
         else:
             raise TypeError('command name must be a string')
+
+    @property
+    def filename(self):
+        if 'filename' in self.state:
+            return self.state['filename']
+
+    @filename.setter
+    def filename(self, value):
+        if isinstance(value, basestring):
+            self.state['filename'] = value
+        else:
+            raise TypeError('filename must be a string')
 
     @property
     def directive(self):

--- a/giza/giza/content/options/tasks.py
+++ b/giza/giza/content/options/tasks.py
@@ -44,11 +44,16 @@ def option_tasks(conf):
 
     tasks = []
     for dep_fn, option in o.content_iter():
-        filename = option.program.replace(' ', '-')
+        program = option.program.replace(' ', '-')
+
+        if option.has_field('filename'):
+            option_name = option.filename
+        else:
+            option_name = option.name
 
         output_fn = os.path.join(conf.system.content.options.fn_prefix,
-                                 ''.join((option.directive, '-', filename,
-                                          '-', option.name + '.rst')))
+                                 ''.join((option.directive, '-', program,
+                                          '-', option_name + '.rst')))
 
         t = Task(job=write_options,
                  args=(option, output_fn, conf),


### PR DESCRIPTION
This doesn't actually work, and I'm not sure why. When I build, it doesn't seem to even be *aware* that there's a `filename` field, and yet there definitely is?

[Here's the commit I've got in the docs repo for it…](https://github.com/schmalliso/docs-mongodb/commit/2965f32003851aadd3a433e772ebcea8a326471b)