### PR TITLE
Removed G+ icon and link. Replaced with Stack Overflow per MongoDB.com.

### DIFF
--- a/themes/mongodb/layout.html
+++ b/themes/mongodb/layout.html
@@ -308,7 +308,7 @@
              <a class="twitter-icon" href="https://twitter.com/MongoDB"><i class="fa fa-twitter-square"></i></a>
              <a class="youtube-icon" href="https://www.youtube.com/user/MongoDB"><i class="fa fa-youtube-square"></i></a>
              <a class="facebook-icon" href="https://www.facebook.com/mongodb"><i class="fa fa-facebook-square"></i></a>
-             <a class="gplus-icon" href="https://plus.google.com/u/1/101024085748034940765/posts?cfem=1"><i class="fa fa-google-plus-square"></i></a>
+             <a class="stack-overflow-icon" href="https://stackoverflow.com/tags/mongodb/info"><i class="fa fa-stack-overflow" aria-hidden="true"></i></a>
            </div>
         {% endblock %}
       </div>


### PR DESCRIPTION
The G+ link has been broken for a while. MongoDB.com does not use it, but it does use Stack Overflow. I swapped in SO for G+.