### PR TITLE
DOCSP-998: Prevent sidebar overlapping main content.

### DIFF
--- a/themes/mongodb/src/css/mongodb-docs.css
+++ b/themes/mongodb/src/css/mongodb-docs.css
@@ -717,6 +717,7 @@ div.versionadded > p > span, div.versionchanged > p > span, div.deprecated > p >
     -webkit-justify-content: center;
             justify-content: center;
     display: inline-block;
+    overflow-x: scroll;
 
 }
 


### PR DESCRIPTION
Related PR on `mongodb/docs-landing`: [https://github.com/mongodb/docs-landing/pull/10](https://github.com/mongodb/docs-landing/pull/10)