### PR TITLE
Handle detached HEAD in Giza

### DIFF
--- a/giza/giza/libgiza/git.py
+++ b/giza/giza/libgiza/git.py
@@ -262,7 +262,7 @@ class GitRepo(object):
             return False
 
     def current_branch(self):
-        return self.cmd('symbolic-ref', 'HEAD').split('/')[2]
+        return self.cmd('rev-parse', '--abbrev-ref', 'HEAD')
 
     def sha(self, ref='HEAD'):
         return self.cmd('rev-parse', '--verify', ref)


### PR DESCRIPTION
Use a Git command to find the branch name that is more friendly
to detached heads, by returning HEAD instead of an error

@i80and, please review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs-tools/189)
<!-- Reviewable:end -->
