### PR TITLE
Add stitch interface tabs

### DIFF
--- a/sphinxext/tabs.py
+++ b/sphinxext/tabs.py
@@ -177,6 +177,14 @@ def setup(app):
         ])
     )
 
+    app.add_directive(
+        'tabs-stitch-interfaces',
+        create_tab_directive('stitchInterfaces', [
+            ('stitch-ui', 'Stitch UI'),
+            ('import-export', 'Import/Export')
+        ])
+    )
+
     # Create general purpose tab directive with no error checking
     app.add_directive('tabs', template.create_directive('tabs', build_template('', ''), template.BUILT_IN_PATH, True))
 


### PR DESCRIPTION
## Overview
Adds tabs for both methods of developing Stitch applications (**Import/Export** and **Stitch UI**)

## Usage
```restructuredtext
.. tabs-stitch-interfaces::
          
   hidden: true
   tabs:
     - id: stitch-ui
       content: |
         Some Stitch UI content

     - id: import-export
       content: |
         Some Import/Export content
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs-tools/201)
<!-- Reviewable:end -->
