### PR TITLE
(DOCSP-3267): Fix OpenAPI Build Warning

### DIFF
--- a/sphinxext/sphinx_openapi.py
+++ b/sphinxext/sphinx_openapi.py
@@ -213,6 +213,7 @@ Base URL
 
    {{ response.jsonSchema }}
 
+{{ if response.jsonFields }}
 .. list-table::
    :header-rows: 1
    :widths: 40 10 50
@@ -222,6 +223,7 @@ Base URL
      - Description
 
 {{ for field in response.jsonFields }}
+
    * - ``{{ field.name }}``
      - {{ field.type }}
      -
@@ -233,7 +235,9 @@ Base URL
        - ``{{ val }}``
 
        {{ end }}
-       {{ end }}
+
+{{ end }}
+{{ end }}
 
 {{ end }}
 {{ end }}


### PR DESCRIPTION
[Jira Ticket](https://jira.mongodb.org/browse/DOCSP-3267)

This fix adds conditional `list-table` rendering when a response doesn't explicitly define response fields (e.g. [this 204 response](https://github.com/10gen/baas-docs/blob/master/source/openapi-admin-v3.yaml#L264)).