### PR TITLE
Updates for Charts GA

### DIFF
--- a/data/charts-published-branches.yaml
+++ b/data/charts-published-branches.yaml
@@ -11,5 +11,8 @@ git:
     manual: 'master'
     published:
       - 'master'
-      - 'on-prem-GA'
+      - '19-06'
+
+      # the branches/published list **must** be ordered from most to
+      # least recent release.
 ...

--- a/data/charts-published-branches.yaml
+++ b/data/charts-published-branches.yaml
@@ -1,26 +1,15 @@
 version:
   published:
     - 'Atlas'
-    - '0.12'
-    - '0.11'
-    - '0.10'
-    - '0.9'
+    - '19.06 (On-Prem)'
   active:
     - 'Atlas'
-    - '0.12'
-    - '0.11'
-    - '0.10'
-    - '0.9'
+    - '19.06 (On-Prem)'
   stable: ''
 git:
   branches:
     manual: 'master'
     published:
       - 'master'
-      - 'v0.12'
-      - 'v0.11'
-      - 'v0.10'
-      - 'v0.9'
-      # the branches/published list **must** be ordered from most to
-      # least recent release.
+      - 'on-prem-GA'
 ...

--- a/themes/charts/page.html
+++ b/themes/charts/page.html
@@ -25,11 +25,11 @@
         <div class="alert alert-info">
           <span class="alert-message">
 
-            This documentation refers to the MongoDB Charts beta 
+            This documentation refers to the MongoDB Charts 
             service in MongoDB Atlas. Read the
             <a href="https://docs.mongodb.com/charts/onprem/">
             on-premises documentation</a> to learn how to use the
-            MongoDB Charts beta on site.
+            MongoDB Charts on site.
 
           </span>
         </div>
@@ -38,10 +38,10 @@
           <span class="alert-message">
 
             This documentation refers to the on-premises edition
-            of MongoDB Charts beta. Read the 
+            of MongoDB Charts. Read the 
             <a href="https://docs.mongodb.com/charts/master/">Atlas
             service documentation</a> to learn how to use MongoDB 
-            Charts beta with your Atlas project.
+            Charts with your Atlas project.
 
           </span>
         </div>


### PR DESCRIPTION
**Please do not merge until Thursday, June 13th afternoon**

We need to:

1. Remove `beta` from the top-level banner.
2. Unpublish all beta docs prior to and equal to 0.12.
3. Create a new release docset called "19.06". Per the Charts status meeting, we will label this `19.06 (On-Prem)` in the UI. The corresponding github branch is `19-06`.