### PR TITLE
DOCSP-5037: Data Lake Configuration Reference

### DIFF
--- a/sphinxext/mongodb_conf.py
+++ b/sphinxext/mongodb_conf.py
@@ -324,6 +324,13 @@ conf['directives'] = [
         'prepend': False,
         'callable': False
     },
+    {
+        'name': 'datalakeconf',
+        'tag': 'datalakeconf',
+        'description': 'Data Lake Configuration Object',
+        'prepend': True,
+        'callable': False
+    },
 ]
 
 ## If prepend: True, you can have a page title that match the directive.  For example, an operator X in a page with title X.  Otherwise, you can't have in page with same title and you'll get iddup as the reference.


### PR DESCRIPTION
This is required to support DOCSP-5037 in cloud-docs. 