### PR TITLE
DOCS-12158: 4.2 manual ga (part2)

### DIFF
--- a/data/manual-published-branches.yaml
+++ b/data/manual-published-branches.yaml
@@ -19,7 +19,7 @@ version:
   upcoming: null
 git:
   branches:
-    manual: 'v4.2'
+    manual: 'master'
     published:
       - 'master'
       - 'v4.0'


### PR DESCRIPTION
Upon cursory look, I think this is what appends the (current) 

My cursory search has:

https://github.com/mongodb/docs-tools/blob/ebf42b4f03ee323d6916692a685f546240dc54c1/giza/giza/config/git.py#L94-L101

and then

https://github.com/mongodb/docs-tools/blob/ebf42b4f03ee323d6916692a685f546240dc54c1/giza/giza/config/project.py#L21-L44

