### PR TITLE
(DOCSP-6535): Updated branches for OM 4.3, 4.4

### DIFF
--- a/data/mms-published-branches.yaml
+++ b/data/mms-published-branches.yaml
@@ -1,6 +1,8 @@
 version:
   published:
     - 'upcoming'
+    - '4.3 (rapid)'
+    - '4.2'
     - '4.1 (rapid)'
     - '4.0'
     - '3.6'
@@ -15,17 +17,21 @@ version:
     - '1.1'
   active:
     - 'upcoming'
+    - '4.3 (rapid)'
+    - '4.2'
     - '4.1 (rapid)'
     - '4.0'
     - '3.6'
     - '3.4'
-  stable: '4.0'
-  upcoming: '4.2'
+  stable: '4.2'
+  upcoming: '4.4'
 git:
   branches:
-    manual: 'v4.0'
+    manual: 'v4.2'
     published:
       - 'master'
+      - 'v4.3'
+      - 'v4.2'
       - 'v4.1'
       - 'v4.0'
       - 'v3.6'


### PR DESCRIPTION
This prepares the `mms-docs` repo for v4.3 and v4.4. It will need to be released for MongoDB 4.2 today (13 Aug 2019).