### PR TITLE
DOCSP-7119: prepend for bsontype directive

### DIFF
--- a/sphinxext/mongodb_conf.py
+++ b/sphinxext/mongodb_conf.py
@@ -102,7 +102,7 @@ conf['directives'] = [
         'name': 'bsontype',
         'tag': 'bson',
         'description': 'BSON type',
-        'prepend': False,
+        'prepend': True,
         'callable': False,
     },
     {


### PR DESCRIPTION
Need to prepend the tag to bsontypes to distinguish between other directives (e.g. method Date/ObjectId/UUID vs bsontype Date/ObjectId/UUID)