### PR TITLE
(DOCSP-7436): adding k8s-op-om-setting directive

### DIFF
--- a/sphinxext/mongodb_conf.py
+++ b/sphinxext/mongodb_conf.py
@@ -331,6 +331,13 @@ conf['directives'] = [
         'prepend': True,
         'callable': False
     },
+    {
+        'name': 'k8s-op-om-setting',
+        'tag': 'k8s-op-om-setting',
+        'description': 'Kubernetes Operator Ops Manager Resource Setting',
+        'prepend': True,
+        'callable': False
+    }    
 ]
 
 ## If prepend: True, you can have a page title that match the directive.  For example, an operator X in a page with title X.  Otherwise, you can't have in page with same title and you'll get iddup as the reference.

--- a/sphinxext/mongodb_conf.py
+++ b/sphinxext/mongodb_conf.py
@@ -332,8 +332,8 @@ conf['directives'] = [
         'callable': False
     },
     {
-        'name': 'k8s-op-om-setting',
-        'tag': 'k8s-op-om-setting',
+        'name': 'omk8sop',
+        'tag': 'omk8sop',
         'description': 'Kubernetes Operator Ops Manager Resource Setting',
         'prepend': True,
         'callable': False

--- a/sphinxext/mongodb_conf.py
+++ b/sphinxext/mongodb_conf.py
@@ -332,8 +332,8 @@ conf['directives'] = [
         'callable': False
     },
     {
-        'name': 'omk8sop',
-        'tag': 'omk8sop',
+        'name': 'opsmgrkube',
+        'tag': 'opsmgrkube',
         'description': 'Kubernetes Operator Ops Manager Resource Setting',
         'prepend': True,
         'callable': False


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOCSP-7436)

adding new directive to work around issue with reusing :settings: with the same name on multiple pages