### PR TITLE
DOCSP-7374 - Add tabs for k8s orchestrator.

### DIFF
--- a/sphinxext/tabs.py
+++ b/sphinxext/tabs.py
@@ -342,6 +342,14 @@ def setup(app):
         ])
     )
 
+    # Create k8s orchestrator tab directive
+    app.add_directive('tabs-k8s-orchestrator',
+        create_tab_directive('k8sorchestrator',
+            [('k8s', 'Kubernetes'),
+             ('openshift', 'OpenShift')
+        ])
+    )
+
     # Create general purpose tab directive with no error checking
     app.add_directive('tabs', create_tab_directive('', []))
 


### PR DESCRIPTION
Staged: https://docs-mongodbcom-staging.corp.mongodb.com/kubernetes-operator/jdestefano/DOCSP-7374/tutorial/deploy-standalone.html

Builds clean without error symlinked on my local:
```
~/git/docs-k8s-operator(DOCSP-7374) $ make clean-html
rm -rf build/DOCSP-7374
giza make html
INFO:giza.operations.make:running sphinx build operation, equivalent to: giza sphinx --builder html
INFO:giza.content.assets:updated /Users/jdestefano/git/docs-k8s-operator/build/docs-tools repository
INFO:giza.content.source:created directory for sphinx build: /Users/jdestefano/git/docs-k8s-operator/build/DOCSP-7374/source
INFO:giza.content.source:prepared and migrated source for sphinx build in /Users/jdestefano/git/docs-k8s-operator/build/DOCSP-7374/source
INFO:giza.operations.sphinx:adding builder job for html (None, None)
INFO:giza.content.sphinx:Starting sphinx build: sphinx-build -t website -t web -t html -q -b html -j 4 -c /Users/jdestefano/git/docs-k8s-operator -d /Users/jdestefano/git/docs-k8s-operator/build/DOCSP-7374/doctrees-html /Users/jdestefano/git/docs-k8s-operator/build/DOCSP-7374/source /Users/jdestefano/git/docs-k8s-operator/build/DOCSP-7374/html
INFO:giza.content.sphinx:completed html sphinx build for kubernetes-operator.kubernetes-operator.DOCSP-7374 (0)
INFO:giza.files:created tarball: /Users/jdestefano/git/docs-k8s-operator/build/public/DOCSP-7374/kubernetes-operator-DOCSP-7374.tar.gz
INFO:giza.operations.sphinx:builds finalized. sphinx output and errors to follow
INFO:giza.content.sphinx:sphinx builder has 1 lines of output, processed from 2
```