### PR TITLE
update kafka branches

### DIFF
--- a/data/kafka-connector-published-branches.yaml
+++ b/data/kafka-connector-published-branches.yaml
@@ -1,9 +1,9 @@
 version:
   published:
-    - 'master'
+    - '0.2'
   active:
-    - 'master'
-  stable: ''
+    - '0.2'
+  stable: '0.2'
   upcoming: ''
 git:
   branches:


### PR DESCRIPTION
Updates kafka branches for 0.2 only without displaying current next to it because it looks like 💩 