### PR TITLE
DOCSP-8255: Fix meta builds

### DIFF
--- a/themes/manual/pagenav.html
+++ b/themes/manual/pagenav.html
@@ -5,7 +5,7 @@
   <a class="index-link" href="{{ pathto('index') }}">{{ shorttitle }}</a>
 </h3>
 
-{{ version_selector() }}
+{% if project != 'mongodb-meta' %}{{ version_selector() }}{% endif %}
 
 {{ toctree( collapse=false, titles_only=1) }}
 

--- a/themes/mongodb/layout.html
+++ b/themes/mongodb/layout.html
@@ -12,7 +12,8 @@
     <div class="btn-group version-sidebar">
       <button type="button" class="version-button dropdown-toggle" data-toggle="dropdown">
         {% set version = theme_version_selector|selectattr('current')|map(attribute='text')|first|e %}
-        {% if version.split()[0]|int != 0 %}Version {% endif %}{{ version }}<span class="caret"></span>
+        {% if version is defined %}{% set version_num = version.split()[0] %}{% endif %}
+        {% if (version_num is defined) and (version_num|int != 0) %}Version {% endif %}{{ version }}<span class="caret"></span>
       </button>
       <ul class="dropdown-menu" role="menu">
         {% for v in theme_version_selector %}
@@ -22,7 +23,8 @@
           <li>
           {% endif %}
             <a {% if not v.current %}class="version-selector" {% endif %}href="#" data-path="{{ v.path }}">
-              {% if v.text.split()[0]|int != 0 %}Version {% endif %}{{ v.text }}
+              {% if v.text is defined %}{% set version_num = v.text.split()[0] %}{% endif %}
+              {% if (version_num is defined) and (version_num|int != 0) %}Version {% endif %}{{ v.text }}
             </a>
           </li>
         {% endfor %}


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-8255)] [[Meta Staging](https://docs-mongodbcom-staging.corp.mongodb.com/meta/sophstad/master/index.html)]
- Add more robust error handling for generating version dropdown labels
- Since `docs-meta` is not a versioned repo, hide the version dropdown from the site. This implementation is a little hacky, but I imagine meta will be moved on to next-gen before too long.