### PR TITLE
(DOCSP-8688): Update Platform Terms

### DIFF
--- a/sphinxext/tabs.py
+++ b/sphinxext/tabs.py
@@ -275,14 +275,30 @@ def setup(app):
     app.add_directive('tabs-cloud',
         create_tab_directive('cloud', DEPLOYMENTS));
 
-    # Create operating system tab directive
+    # Create client operating system tab directive
     app.add_directive('tabs-platforms',
         create_tab_directive('platforms',
             [('windows', 'Windows'),
              ('macos', 'macOS'),
-             ('linux', 'Linux'),
+             ('debian', 'Ubuntu/Debian'),
+             ('rhel', 'RHEL/CentOS/AMZ'),
+             ('linux', 'Linux')]))
+
+    # Create server operating system tab directive
+    app.add_directive('tabs-server-platforms',
+        create_tab_directive('server-platforms',
+            [
+             ('windows', 'Windows'),
+             ('deb', 'Ubuntu/Debian'),
+             ('rpm', 'RHEL/CentOS/AMZ'),
              ('debian', 'Debian'),
-             ('rhel', 'RHEL')]))
+             ('ubuntu', 'Ubuntu'),
+             ('rhel', 'RHEL/CentOS'),
+             ('suse', 'SUSE'),
+             ('amz', 'Amazon Linux'),
+             ('linux', 'Other Linux')
+            ]))
+
 
     # Create Realm SDK tab directive
     app.add_directive(


### PR DESCRIPTION
@i80and : This change helps users understand that Debian and Ubuntu are the same thing (generally) and adds a new tab type for server platforms.

(This simplifies the request in [DOCSP-8688](https://jira.mongodb.org/browse/DOCSP-8688) asking to pull out Ubuntu from Debian, even though every download for our products equates the two. Discussed with James Broadhead and Andrey Belik from Private Cloud.)