### PR TITLE
(DOCSP-8688): Updated Platform Tab Labels

### DIFF
--- a/sphinxext/tabs.py
+++ b/sphinxext/tabs.py
@@ -275,14 +275,30 @@ def setup(app):
     app.add_directive('tabs-cloud',
         create_tab_directive('cloud', DEPLOYMENTS));
 
-    # Create operating system tab directive
+    # Create client operating system tab directive
     app.add_directive('tabs-platforms',
         create_tab_directive('platforms',
             [('windows', 'Windows'),
              ('macos', 'macOS'),
-             ('linux', 'Linux'),
+             ('debian', 'Ubuntu/Debian'),
+             ('rhel', 'RHEL/CentOS/AMZ'),
+             ('linux', 'Linux')]))
+
+    # Create server operating system tab directive
+    app.add_directive('tabs-server-platforms',
+        create_tab_directive('server-platforms',
+            [
+             ('windows', 'Windows'),
+             ('deb', 'Ubuntu/Debian'),
+             ('rpm', 'RHEL/CentOS/AMZ'),
              ('debian', 'Debian'),
-             ('rhel', 'RHEL')]))
+             ('ubuntu', 'Ubuntu'),
+             ('rhel', 'RHEL/CentOS'),
+             ('suse', 'SUSE'),
+             ('amz', 'Amazon Linux'),
+             ('linux', 'Other Linux')
+            ]))
+
 
     # Create Realm SDK tab directive
     app.add_directive(

--- a/sphinxext/tabs.py
+++ b/sphinxext/tabs.py
@@ -275,7 +275,7 @@ def setup(app):
     app.add_directive('tabs-cloud',
         create_tab_directive('cloud', DEPLOYMENTS));
 
-    # Create client operating system tab directive
+    # Create operating system tab directive
     app.add_directive('tabs-platforms',
         create_tab_directive('platforms',
             [('windows', 'Windows'),
@@ -283,22 +283,6 @@ def setup(app):
              ('debian', 'Ubuntu/Debian'),
              ('rhel', 'RHEL/CentOS/AMZ'),
              ('linux', 'Linux')]))
-
-    # Create server operating system tab directive
-    app.add_directive('tabs-server-platforms',
-        create_tab_directive('server-platforms',
-            [
-             ('windows', 'Windows'),
-             ('deb', 'Ubuntu/Debian'),
-             ('rpm', 'RHEL/CentOS/AMZ'),
-             ('debian', 'Debian'),
-             ('ubuntu', 'Ubuntu'),
-             ('rhel', 'RHEL/CentOS'),
-             ('suse', 'SUSE'),
-             ('amz', 'Amazon Linux'),
-             ('linux', 'Other Linux')
-            ]))
-
 
     # Create Realm SDK tab directive
     app.add_directive(


### PR DESCRIPTION
@i80and : I checked it all out. 

Built successfully:

```
➜  mms-docs git:(DOCSP-8815) make clean-html-opsmgr
rm -rf build/DOCSP-8815
giza make html-onprem
INFO:giza.operations.make:running sphinx build operation, equivalent to: giza sphinx --builder html --edition onprem
INFO:giza.content.assets:updated /home/atsansone/projects/mms-docs/source/figures repository
INFO:giza.content.assets:updated /home/atsansone/projects/mms-docs/build/docs-tools repository
INFO:giza.content.source:created directory for sphinx build: /home/atsansone/projects/mms-docs/build/DOCSP-8815/source-onprem
INFO:giza.content.source:redacted 27 files
INFO:giza.content.source:prepared and migrated source for sphinx build in /home/atsansone/projects/mms-docs/build/DOCSP-8815/source-onprem
INFO:giza.content.robots:cowardly refusing to regenerate robots.txt on non-master branch.
INFO:giza.operations.sphinx:adding builder job for html (None, onprem)
INFO:giza.content.sphinx:Starting sphinx build: sphinx-build -t website -t onprem -t html -t web -t hosted -q -b html -c /home/atsansone/projects/mms-docs -d /home/atsansone/projects/mms-docs/build/DOCSP-8815/doctrees-html-onprem /home/atsansone/projects/mms-docs/build/DOCSP-8815/source-onprem /home/atsansone/projects/mms-docs/build/DOCSP-8815/html-onprem
INFO:giza.content.sphinx:completed html sphinx build for mms.onprem.DOCSP-8815 (0)
INFO:giza.files:created tarball: /home/atsansone/projects/mms-docs/build/public/onprem/DOCSP-8815/mms-onprem-DOCSP-8815.tar.gz
INFO:giza.operations.sphinx:builds finalized. sphinx output and errors to follow
INFO:giza.content.sphinx:sphinx builder has 1 lines of output, processed from 320
➜  mms-docs git:(DOCSP-8815) tmux capture-pane -pS -50 > ../build-log/DOCSP-8688.txt
```

![image](https://user-images.githubusercontent.com/706219/74072523-b4945f00-49cc-11ea-8672-816eb7ce094d.png)
