### PR TITLE
DOCSP-9010: Add new theme for docs.mongodb.com/database-tools

### DIFF
--- a/themes/database-tools/footer.html
+++ b/themes/database-tools/footer.html
@@ -1,0 +1,17 @@
+<div class="footer row">
+  <div class="box col-md-12">
+    <div class="row">
+      <div class="col-xs-6 col-sm-3 section-0">
+        {%- include "intrasite-about.html" %}
+      </div>
+      <div class="col-xs-6 col-sm-3 section-1">
+        {%- include "resources.html" %}
+      </div>
+      <div class="col-xs-6 col-sm-3 section-2">
+        {%- include "intrasite-ecosystem.html" %}
+      </div>
+      <div class="col-xs-6 col-sm-3 section-3">
+        {%- include "intrasite-drivers.html" %}
+      </div>
+  </div>
+</div>

--- a/themes/database-tools/page.html
+++ b/themes/database-tools/page.html
@@ -1,0 +1,74 @@
+{%- extends "layout.html" -%}
+
+{%- block htmltitle %}
+  {%- if not embedded and docstitle %}
+    {%- set titlesuffix = " &mdash; "|safe + docstitle|e + " " + release|e %}
+  {%- else %}
+    {%- set titlesuffix = "" %}
+  {%- endif -%}
+
+  <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
+{%- endblock -%}
+
+{%- block editlink_icon %}{% endblock %}
+
+{%- block canonicalref %}
+  {%- if pagename == 'index' %}
+    <link rel="canonical" href="http://docs.mongodb.com/{{theme_project}}/" />
+  {%- else %}
+    <link rel="canonical" href="http://docs.mongodb.com/{{theme_project}}/{{pagename}}" />
+  {%- endif -%}
+{%- endblock -%}
+
+{%- block alertbar -%}
+    {%- if theme_active_branches and version not in theme_active_branches %}
+        <div class="alert alert-info">
+           <span class="alert-message">This version of the manual is no longer supported.</span>
+        </div>
+    {%- endif %}
+    {%- if theme_is_upcoming %}
+        <div class="alert alert-info">
+           <span class="alert-message">This manual pertains to an upcoming
+           release, and is made available for testing purposes only.</span>
+        </div>
+    {%- elif theme_eol %}
+        <div class="alert alert-warning">
+           <span class="alert-message">{{theme_eol_msg}}</span>
+        </div>
+    {%- elif theme_banner %}
+        <div class="alert alert-info">
+           <span class="alert-message">{{theme_banner_msg}}</span>
+        </div>
+    {%- endif %}
+{%- endblock -%}
+
+{%- block adblockheader %}
+    {%- include "adblock-header.html" %}
+{%- endblock -%}
+
+{%- block adblock %}
+    {%- include "adblock.html" %}
+{%- endblock -%}
+
+{%- block sitesearch %}
+  {%- if builder != 'singlehtml' %}
+      <script>
+        window.googleSearchCx = "014132741538533607290:cgznrev_wu0"
+	window.googleSearchPlaceholder = "Search MongoDB Database Tools"
+        window.googleSearchResultsUrl = "https://docs.mongodb.com/{{theme_project}}/search/"
+      </script>
+  {%- endif %}
+{%- endblock -%}
+
+{%- block header %}
+<div id="navbar" data-navprops='{"links": [{"url": "https://docs.mongodb.com/manual/","text": "Server"},{"url": "https://docs.mongodb.com/ecosystem/drivers/","text": "Drivers"},{"url": "https://docs.mongodb.com/cloud/","text": "Cloud"},{"url": "https://docs.mongodb.com/tools/","text": "Tools","active": true},{"url": "https://docs.mongodb.com/guides/","text": "Guides"}]}'></div>
+{%- endblock %}
+
+
+{%- block langauge_selector %}{%- endblock -%}
+{% block version_selector %}{% endblock %}
+{%- block pdflink %}{%- endblock %}
+{%- block epublink %}{%- endblock %}
+{%- block righttoc %} {% endblock %}
+
+

--- a/themes/database-tools/pagenav.html
+++ b/themes/database-tools/pagenav.html
@@ -1,0 +1,8 @@
+<a href="javascript:void(0)" class="closeNav" id="closeNav">Close &times;</a>
+
+
+<h3>
+  <a class="index-link" href="{{ pathto('index') }}">{{ shorttitle }}</a>
+</h3>
+
+{{ toctree( collapse=false, titles_only=1) }}

--- a/themes/database-tools/search.html
+++ b/themes/database-tools/search.html
@@ -1,0 +1,49 @@
+{#
+    basic/search.html
+    ~~~~~~~~~~~~~~~~~
+
+    Template for the search page.
+
+    :copyright: Copyright 2007-2011 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+#}
+{% extends "page.html" %}
+{% set title = _('Search') %}
+
+{% block body %}
+<style>.edit-link {display: none}</style>
+
+  <div class="section search-header">
+    <h1 id="search-documentation">{{ _('Search') }}</h1>
+    <div id="fallback" class="admonition warning">
+    <script type="text/javascript">
+      $('#fallback').hide();
+
+      // hide unnecessary text if we are displaying search results
+      if ((function getParameterByName(name) {
+        name = name.replace(/[\[]/, "\\\[").replace(/[\]]/, "\\\]");
+        var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
+            results = regex.exec(location.search);
+        return results == null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+      })('query')) {
+        $('.search-header').hide();
+      }
+    </script>
+    <p>
+      {% trans %}Please activate JavaScript to enable the search
+      functionality.{% endtrans %}
+    </p>
+    </div>
+    <p>
+      {% trans %}From here you can view your search results. Enter your search
+      words into the box at the top right of the page and press "Enter". Note that the search
+      function will automatically search for all of the words. Pages
+      containing fewer words won't appear in the result list.{% endtrans %}
+    </p>
+  </div>
+  {% block gcseresults %}
+    <div id="cse-results">
+      <gcse:searchresults-only linkTarget="_top" queryParameterName="query"></gcse:searchresults-only>
+    </div>
+  {% endblock %}
+{% endblock %}

--- a/themes/database-tools/theme.conf
+++ b/themes/database-tools/theme.conf
@@ -1,0 +1,23 @@
+[theme]
+inherit = mongodb
+stylesheet = mongodb-docs.css
+pygments_style = sphinx
+
+[options]
+branch = BRANCH
+pdfpath = PDFPATH
+epubpath = EPUBPATH
+manual_path = PATH
+repo_name = REPONAME
+jira_project = JIRA
+google_analytics = GACODE
+project = PROJECT
+translations = LANGUAGES
+language = LANGUAGE
+version = VERSION
+version_selector = VERSION_SELECTOR
+latest = LATEST
+stable = STABLE
+sitename = MongoDB
+nav_excluded = NAV
+is_upcoming =


### PR DESCRIPTION
Theme required for docs.mongodb.com/database-tools

We're currently using the local fork for this. Once this is merged to master, we can switch back to docs-tools core.

cc @jdestefano-mongo 