### PR TITLE
(DOCSP-9364): Create mongocli-published-branches.yaml

### DIFF
--- a/data/mongocli-publishsed-branches.yaml
+++ b/data/mongocli-publishsed-branches.yaml
@@ -1,12 +1,12 @@
 version:
   published:
-    - 'v0.0.4'
-    - 'v0.0.3'
+    - '0.0.4'
+    - '0.0.3'
   active:
-    - 'v0.0.4'
-    - 'v0.0.3'
-  stable: 'v0.0.3'
-  upcoming: 'v0.0.4'
+    - '0.0.4'
+    - '0.0.3'
+  stable: '0.0.3'
+  upcoming: '0.0.4'
 git:
   branches:
     manual: 'v0.0.4'

--- a/data/mongocli-publishsed-branches.yaml
+++ b/data/mongocli-publishsed-branches.yaml
@@ -1,0 +1,15 @@
+version:
+  published:
+    - '0.0.3'
+  active:
+    - '0.0.3'
+  stable: ''
+  upcoming: ''
+git:
+  branches:
+    manual: 'master'
+    published:
+      - 'master'
+      # the branches/published list **must** be ordered from most to
+      # least recent release.
+...

--- a/data/mongocli-publishsed-branches.yaml
+++ b/data/mongocli-publishsed-branches.yaml
@@ -1,15 +1,18 @@
 version:
   published:
-    - '0.0.3'
+    - 'v0.0.4'
+    - 'v0.0.3'
   active:
-    - '0.0.3'
-  stable: ''
-  upcoming: ''
+    - 'v0.0.4'
+    - 'v0.0.3'
+  stable: 'v0.0.3'
+  upcoming: 'v0.0.4'
 git:
   branches:
-    manual: 'master'
+    manual: 'v0.0.4'
     published:
       - 'master'
+      - 'v0.0.3'
       # the branches/published list **must** be ordered from most to
       # least recent release.
 ...


### PR DESCRIPTION
Created a published branches yaml file for the new 10gen/mongocli repo.

There will be a current v0.0.3 and an upcoming v0.0.4. The current is based off the v0.0.3 branch, and the upcoming is based on master.