### PR TITLE
Add new path location for Inkscape 1.0+ on OS Mojave or later

### DIFF
--- a/giza/giza/content/images/tasks.py
+++ b/giza/giza/content/images/tasks.py
@@ -57,7 +57,8 @@ def generate_image_inkscape(build_type, dpi, width, target, source):
     inkscape = None
 
     for path in ('/usr/bin/inkscape', '/usr/local/bin/inkscape',
-                 '/Applications/Inkscape.app/Contents/Resources/bin/inkscape'):
+                 '/Applications/Inkscape.app/Contents/Resources/bin/inkscape',
+                 '/Applications/Inkscape.app/Contents/MacOS/inkscape'):
         if os.path.exists(path):
             inkscape = path
             break


### PR DESCRIPTION
Hi All,

This adds an additional file to check for the image generation to account for recent changes in Inkscape and in OS X (Mojave or later) as to where the binary file for Inkscape is installed. This should allow people to use Giza with Inkscape 1.0+ on OS X. If you install the docs-tool chain and attempt to generate images this function won't be able to locate the binary due to the new location of the inkscape binary (1.0+).

Thanks!
Eoin