### PR TITLE
(DOCSP-10269): Remove pre-1.0 versions of k8s docs

### DIFF
--- a/data/kubernetes-operator-published-branches.yaml
+++ b/data/kubernetes-operator-published-branches.yaml
@@ -7,11 +7,6 @@ version:
     - '1.2'
     - '1.1'
     - '1.0'
-    - '0.12'
-    - '0.11'
-    - '0.10'
-    - '0.9'
-    - '0.8'
   active:
     - '1.6'
     - '1.5'
@@ -20,11 +15,6 @@ version:
     - '1.2'
     - '1.1'
     - '1.0'
-    - '0.12'
-    - '0.11'
-    - '0.10'
-    - '0.9'
-    - '0.8'
   stable: '1.5'
   upcoming: '1.6'
 git:
@@ -38,11 +28,6 @@ git:
       - 'v1.2'
       - 'v1.1'
       - 'v1.0'
-      - 'v0.12'
-      - 'v0.11'
-      - 'v0.10'
-      - 'v0.9'
-      - 'v0.8'
       # the branches/published list **must** be ordered from most to
       # least recent release.
 ...

--- a/data/kubernetes-operator-published-branches.yaml
+++ b/data/kubernetes-operator-published-branches.yaml
@@ -7,6 +7,11 @@ version:
     - '1.2'
     - '1.1'
     - '1.0'
+    - '0.12'
+    - '0.11'
+    - '0.10'
+    - '0.9'
+    - '0.8'
   active:
     - '1.6'
     - '1.5'
@@ -28,6 +33,11 @@ git:
       - 'v1.2'
       - 'v1.1'
       - 'v1.0'
+      - 'v0.12'
+      - 'v0.11'
+      - 'v0.10'
+      - 'v0.9'
+      - 'v0.8'
       # the branches/published list **must** be ordered from most to
       # least recent release.
 ...

--- a/themes/kubernetes-operator/page.html
+++ b/themes/kubernetes-operator/page.html
@@ -23,7 +23,11 @@
 {%- block alertbar -%}
     {%- if theme_active_branches and version not in theme_active_branches %}
         <div class="alert alert-info">
-           <span class="alert-message">This version of the manual is no longer supported.</span>
+           <span class="alert-message">This version of the manual is no
+           longer supported. <a
+           href="https://docs.mongodb.com/kubernetes-operator/stable/upgrade/">Learn
+           more</a> about upgrading your version of the MongoDB
+           Enterprise Kubernetes Operator.</span>
         </div>
     {%- endif %}
     {%- if theme_is_upcoming %}

--- a/themes/kubernetes-operator/theme.conf
+++ b/themes/kubernetes-operator/theme.conf
@@ -21,3 +21,4 @@ stable = STABLE
 sitename = MongoDB
 nav_excluded = NAV
 is_upcoming =
+active_branches =


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOCSP-10269)

@jdestefano-mongo Could you take a look and make sure I don't need to do anything else? I used the [PR to remove OM 2.0](https://github.com/mongodb/docs-tools/commit/28acc210a6285d128b789bce67f543623ebc96ab) and the PR to [unpublish OM pre-2.0](https://github.com/mongodb/docs-tools/commit/713f8f8df3a1b105459dcaa4086b761a7af89a81) as references.

It looks like [the page knows](https://github.com/mongodb/docs-tools/blob/master/themes/mongocli/page.html#L24) to put a deprecation notice at the top of the docs if the version isn't listed in the active branches. Do I need to add `active_branches =` to the [theme](https://github.com/mongodb/docs-tools/blob/master/themes/mongocli/theme.conf) make this work? The [OM theme](https://github.com/mongodb/docs-tools/blob/master/themes/mms-onprem/theme.conf) doesn't have it but I wasn't sure.