### PR TITLE
DOCSP-11113: Update Kafka Connector versions file to include 1.2

### DIFF
--- a/data/kafka-connector-published-branches.yaml
+++ b/data/kafka-connector-published-branches.yaml
@@ -1,19 +1,22 @@
 version:
   published:
     - 'master'
+    - 'v1.2'
     - 'v1.1'
     - 'v1.0'
   active:
     - 'master'
+    - 'v1.2'
     - 'v1.1'
     - 'v1.0'
-  stable: 'v1.1'
+  stable: 'v1.2'
   upcoming: 'master'
 git:
   branches:
     manual: 'master'
     published:
       - 'master'
+      - 'v1.2'
       - 'v1.1'
       - 'v1.0'
       # the branches/published list **must** be ordered from most to


### PR DESCRIPTION
JIRA: 
https://jira.mongodb.org/browse/DOCSP-11113

No staging (version selector update)