### PR TITLE
prepwork for 4.4 manual publish

### DIFF
--- a/data/manual-published-branches.yaml
+++ b/data/manual-published-branches.yaml
@@ -17,11 +17,11 @@ version:
     - '3.6'
     - '3.4'
     - '3.2'
-  stable: '4.2'
-  upcoming: '4.4'
+  stable: '4.4'
+  upcoming: null
 git:
   branches:
-    manual: 'v4.2'
+    manual: 'master'
     published:
       - 'master'
       - 'v4.2'


### PR DESCRIPTION
Prepwork for the upcoming 4.4 manual publish.  This PR must be merged before the Server Team can publish the 4.4 docs.