### PR TITLE
(DOCSP-11448) Update versions for Ops Manager 4.4.0

### DIFF
--- a/data/mms-published-branches.yaml
+++ b/data/mms-published-branches.yaml
@@ -1,30 +1,27 @@
 version:
   published:
     - 'upcoming'
+    - '4.4'
     - '4.3 (rapid)'
     - '4.2'
     - '4.0'
-    - '3.6'
-    - '3.4'
   active:
     - 'upcoming'
+    - '4.4'
     - '4.3 (rapid)'
     - '4.2'
     - '4.0'
-    - '3.6'
-    - '3.4'
-  stable: '4.2'
-  upcoming: '4.4'
+  stable: '4.4'
+  upcoming: '4.6'
 git:
   branches:
-    manual: 'v4.2'
+    manual: 'v4.4'
     published:
       - 'master'
+      - 'v4.4'
       - 'v4.3'
       - 'v4.2'
       - 'v4.0'
-      - 'v3.6'
-      - 'v3.4'
       # the branches/published list **must** be ordered from most to
       # least recent release.
 ...


### PR DESCRIPTION
@jdestefano-mongo : I followed [these instructions](https://docs.mongodb.com/meta/tutorials/version-bumping/) on Docs Meta. Matches changes done in https://github.com/10gen/mms-docs/pull/3212.
