### PR TITLE
(DOCSP-11490): Update Charts theme to remove redirect to onprem

### DIFF
--- a/themes/charts/page.html
+++ b/themes/charts/page.html
@@ -21,19 +21,7 @@
 {%- endblock -%}
 
 {%- block alertbar -%}
-    {%- if theme_is_saas %}
-        <div class="alert alert-info">
-          <span class="alert-message">
-
-            This documentation refers to the MongoDB Charts 
-            service in MongoDB Atlas. Read the
-            <a href="https://docs.mongodb.com/charts/onprem/">
-            on-premises documentation</a> to learn how to use the
-            MongoDB Charts on site.
-
-          </span>
-        </div>
-    {%- else %}
+    {%- if not theme_is_saas %}
         <div class="alert alert-info">
           <span class="alert-message">
 


### PR DESCRIPTION
We no longer want to have a banner on the saas side directing users to the onprem docs. We just want a banner directing users from onprem -> saas.

staged: 

(non-master branch): https://docs-mongodbcom-staging.corp.mongodb.com/charts/jeffreyallen/DOCSP-11490/index.html

(master / saas branch): https://docs-mongodbcom-staging.corp.mongodb.com/charts/jeffreyallen/master/index.html