### PR TITLE
DOCS-13789 - Remove v2.9 and earlier from the BIC version selector.

### DIFF
--- a/data/bi-connector-published-branches.yaml
+++ b/data/bi-connector-published-branches.yaml
@@ -5,22 +5,12 @@ version:
     - '2.12'
     - '2.11'
     - '2.10'
-    - '2.9'
-    - '2.8'
-    - '2.7'
-    - '2.6'
-    - '2.5'
   active:
     - '2.14'
     - '2.13'
     - '2.12'
     - '2.11'
     - '2.10'
-    - '2.9'
-    - '2.8'
-    - '2.7'
-    - '2.6'
-    - '2.5'
   stable: ''
   upcoming: ''
 git:
@@ -32,11 +22,6 @@ git:
       - 'v2.12'
       - 'v2.11'
       - 'v2.10'
-      - 'v2.9'
-      - 'v2.8'
-      - 'v2.7'
-      - 'v2.6'
-      - 'v2.5'
       # the branches/published list **must** be ordered from most to
       # least recent release.
 ...


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/DOCS-13789