### PR TITLE
(DOP-1631): Update feedback widget to point to Community instead of Google Groups

### DIFF
--- a/themes/mongodb/src/widgets/deluge/MainWidget.js
+++ b/themes/mongodb/src/widgets/deluge/MainWidget.js
@@ -70,7 +70,7 @@ class MainWidget extends preact.Component {
                         href="https://jira.mongodb.org/">
                             report the problem on Jira.</a></p>}
                     <p>We also recommend you explore <a class="deluge-fix-button"
-                        href="https://groups.google.com/group/mongodb-user">
+                        href="https://developer.mongodb.com/community/forums/">
                             the MongoDB discussion forum</a> for additional support.</p>
                     <p className="deluge-close-link"><small><span onClick={this.toggleVisibility}>
                         Close</span></small></p>


### PR DESCRIPTION
**NextGen/Snooty Widget:** https://github.com/mongodb/snooty/pull/318

https://jira.mongodb.org/browse/DOP-1631