### PR TITLE
(DOCSP-13395): Version bump to v1.9

### DIFF
--- a/data/mongocli-published-branches.yaml
+++ b/data/mongocli-published-branches.yaml
@@ -1,5 +1,7 @@
 version:
   published:
+    - '1.10'
+    - '1.9'
     - '1.8'
     - '1.7'
     - '1.6'
@@ -15,6 +17,8 @@ version:
     - '0.0.4'
     - '0.0.3'
   active:
+    - '1.10'
+    - '1.9'
     - '1.8'
     - '1.7'
     - '1.6'
@@ -24,13 +28,15 @@ version:
     - '1.2'
     - '1.1'
     - '1.0'
-  stable: '1.7'
-  upcoming: '1.8'
+  stable: '1.9'
+  upcoming: '1.10'
 git:
   branches:
-    manual: 'v1.8'
+    manual: 'v1.10'
     published:
       - 'master'
+      - 'v1.9'
+      - 'v1.8'
       - 'v1.7'
       - 'v1.6'
       - 'v1.5'


### PR DESCRIPTION
Apparently, I didn't update this file for v1.8 a month ago... oops. This PR bumps the docs to v1.9 (stable) and includes the versions I missed for 1.8.