### PR TITLE
(DOCSP-15037) Retire v4.0

### DIFF
--- a/data/mms-published-branches.yaml
+++ b/data/mms-published-branches.yaml
@@ -4,7 +4,6 @@ version:
     - '4.9 (rapid)'
     - '4.4'
     - '4.2'
-    - '4.0'
   active:
     - 'upcoming'
     - '4.9 (rapid)'
@@ -20,7 +19,6 @@ git:
       - 'v4.9'
       - 'v4.4'
       - 'v4.2'
-      - 'v4.0'
       # the branches/published list **must** be ordered from most to
       # least recent release.
 ...


### PR DESCRIPTION
@i80and : This should retire version 4.0 of the Ops Manager docs per @gssbzn. Please let me know if all looks in order.

