### PR TITLE
DOP-2186, DOP-2112: canonical and title fixes

### DIFF
--- a/themes/mongoid/page.html
+++ b/themes/mongoid/page.html
@@ -6,7 +6,8 @@
   {%- else %}
     {%- set titlesuffix = "" %}
   {%- endif -%}
-
+  <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
+{%- endblock -%}
 
 {%- block canonicalref %}
   {%- if pagename == 'index' %}

--- a/themes/mongoid/page.html
+++ b/themes/mongoid/page.html
@@ -1,5 +1,13 @@
 {%- extends "layout.html" -%}
 
+{%- block htmltitle %}
+  {%- if not embedded and docstitle %}
+    {%- set titlesuffix = " &mdash; "|safe + docstitle|e + " " + release|e %}
+  {%- else %}
+    {%- set titlesuffix = "" %}
+  {%- endif -%}
+
+
 {%- block canonicalref %}
   {%- if pagename == 'index' %}
     <link rel="canonical" href="https://docs.mongodb.com/{{theme_project}}/current/" />

--- a/themes/php-library/page.html
+++ b/themes/php-library/page.html
@@ -12,9 +12,9 @@
 
 {%- block canonicalref %}
   {%- if pagename == 'index' %}
-    <link rel="canonical" href="https://docs.mongodb.com/{{theme_project}}/current/" />
+    <link rel="canonical" href="https://docs.mongodb.com/php-library/current/" />
   {%- else %}
-    <link rel="canonical" href="https://docs.mongodb.com/{{theme_project}}/current/{{pagename}}/" />
+    <link rel="canonical" href="https://docs.mongodb.com/php-library/current/{{pagename}}/" />
   {%- endif -%}
 {%- endblock -%}
 

--- a/themes/ruby-driver/page.html
+++ b/themes/ruby-driver/page.html
@@ -12,9 +12,9 @@
 
 {%- block canonicalref %}
   {%- if pagename == 'index' %}
-    <link rel="canonical" href="https://docs.mongodb.com/{{theme_project}}/current/" />
+    <link rel="canonical" href="https://docs.mongodb.com/ruby-driver/current/" />
   {%- else %}
-    <link rel="canonical" href="https://docs.mongodb.com/{{theme_project}}/current/{{pagename}}/" />
+    <link rel="canonical" href="https://docs.mongodb.com/ruby-driver/current/{{pagename}}/" />
   {%- endif -%}
 {%- endblock -%}
 


### PR DESCRIPTION
## Fixes
- Uses correct URL string for canonical URLs for php-library and ruby-driver, per [DOP-2186](https://jira.mongodb.org/browse/DOP-2186) (for some reason, it was building with docs-php-library and docs-ruby as the theme_project strings. This seems like the easiest fix)

## Additions
- Adds an HTML title block to the mongoid docs so that page titles will have "mongoid" in them, consistent with the ruby docs' format.