### PR TITLE
DOP-2187: only include canonical block if version is active

### DIFF
--- a/themes/mongodb/layout.html
+++ b/themes/mongodb/layout.html
@@ -136,6 +136,7 @@
     <meta name="robots" content="noindex,nofollow" />
   {%- elif version in theme_active_branches or not theme_active_branches %}
     <meta name="robots" content="index" />
+    {%- block canonicalref %}{%- endblock -%}
   {%- else -%}
     <meta name="robots" content="noindex,nofollow" />
   {%- endif %}
@@ -147,8 +148,6 @@
   <meta property="og:image:secure_url" content="https://webassets.mongodb.com/_com_assets/cms/mongodb-for-giant-ideas-bbab5c3cf8.png">
 
   {%- block metadescription %}{%- endblock -%}
-
-  {%- block canonicalref %}{%- endblock -%}
 
   {{ metatags }}
   {{ css() }}


### PR DESCRIPTION
Moves canonicalref block into an if statement so that it only is rendered if the version is in `theme_active_branches`, thus ensuring that we don't have canonical URLs on pages who have `robots: noindex,nofollow`, per advice of SEO consultants.