### PR TITLE
(DOCSP-16023): EOL 4.2 Banner

### DIFF
--- a/data/mms-published-branches.yaml
+++ b/data/mms-published-branches.yaml
@@ -8,7 +8,6 @@ version:
     - 'upcoming'
     - '4.9 (rapid)'
     - '4.4'
-    - '4.2'
   stable: '4.4'
   upcoming: '5.0'
 git:

--- a/themes/mms-onprem/page.html
+++ b/themes/mms-onprem/page.html
@@ -42,6 +42,19 @@
     </div>
   {%- endif %}
 
+  {%- if theme_eol %}
+    <div class="alert alert-warning">
+      <span class="alert-message">{{theme_eol_msg}}</span>
+    </div>
+  {%- elif theme_active_branches and version not in theme_active_branches %}
+    <div class="alert alert-info">
+      <span class="alert-message">This version of the manual is no longer supported.</span>
+      {%- if theme_eol_remove %}
+          <span class="alert-message">It will be removed on {{ theme_eol_date }}.</span>
+      {%- endif %}
+    </div>
+  {%- endif %}
+
 {%- endblock -%}
 
 


### PR DESCRIPTION
This PR corresponds with https://github.com/10gen/mms-docs/pull/3750 . It adds an EOL banner to the 4.2 docs similar to the one implemented in https://github.com/mongodb/docs-tools/pull/481.