### PR TITLE
(DOCSP-16402) Version bump for Kubernetes Operator v1.12

### DIFF
--- a/data/kubernetes-operator-published-branches.yaml
+++ b/data/kubernetes-operator-published-branches.yaml
@@ -13,13 +13,14 @@ version:
     - '1.8'
     - '1.7'
     - '1.6'
-  stable: '1.10'
-  upcoming: '1.11'
+  stable: '1.11'
+  upcoming: '1.12'
 git:
   branches:
-    manual: 'v1.10'
+    manual: 'v1.12'
     published:
       - 'master'
+      - 'v1.11'
       - 'v1.10'
       - 'v1.9'
       - 'v1.8'

--- a/data/kubernetes-operator-published-branches.yaml
+++ b/data/kubernetes-operator-published-branches.yaml
@@ -1,5 +1,6 @@
 version:
   published:
+    - '1.12'
     - '1.11'
     - '1.10'
     - '1.9'
@@ -7,6 +8,7 @@ version:
     - '1.7'
     - '1.6'
   active:
+    - '1.12'
     - '1.11'
     - '1.10'
     - '1.9'
@@ -17,7 +19,7 @@ version:
   upcoming: '1.12'
 git:
   branches:
-    manual: 'v1.12'
+    manual: 'v1.11'
     published:
       - 'master'
       - 'v1.11'


### PR DESCRIPTION
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=60b97baff1f693745039d6b3) - build fails but I have no idea if this is by design.
[Jira](https://jira.mongodb.org/browse/DOCSP-16402)

Created a new version for MEKO, 1.12.
Please review. Please note that in the 10gen/docs-k8s-operator, I only created a 1.11 branch. I didn't create 1.12. Here is the [commit](https://github.com/10gen/docs-k8s-operator/commit/390978c473cecf3a7024221246f7429712d88c91) for the release notes in that repo.