### PR TITLE
DOP-2555: Switch media.mongodb.org favicon to docs s3 bucket

### DIFF
--- a/giza/docs/source/.static/osd.xml
+++ b/giza/docs/source/.static/osd.xml
@@ -5,7 +5,7 @@
 <Description>Google Custom Search of MongoDB documentation (docs.mongodb.org) and wiki (www.mongodb.org/display/DOCS)</Description>
 <Tags>mongodb mongo mongodocs</Tags>
 <Query role="example" searchTerms="mongodb"/>
-<Image height="16" width="16" type="image/vnd.microsoft.icon">http://media.mongodb.org/favicon.ico</Image>
+<Image height="16" width="16" type="image/vnd.microsoft.icon">http://docs.mongodb.com/assets/favicon.ico</Image>
 <Developer>MongoDB, Inc.</Developer>
 <Contact>sitesearch@mongodb.com</Contact>
 <Url type="text/html" rel="results" template="http://www.google.com/cse?cx=017213726194841070573:WMX6838984&amp;ie=UTF-8&amp;q={searchTerms}" />

--- a/themes/guides/layout.html
+++ b/themes/guides/layout.html
@@ -55,7 +55,7 @@
     <title>{{ title|striptags|e }}</title>
   {%- endblock -%}
 
-  <link rel="shortcut icon" href="https://media.mongodb.org/favicon.ico" />
+  <link rel="shortcut icon" href="https://docs.mongodb.com/assets/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="Content-Type" content="text/html; charset={{ encoding }}" />
   <meta name="robots" content="index" />

--- a/themes/mongodb/layout.html
+++ b/themes/mongodb/layout.html
@@ -128,7 +128,7 @@
     <title>{{ title|striptags|e }}</title>
   {%- endblock -%}
 
-  <link rel="shortcut icon" href="https://media.mongodb.org/favicon.ico" />
+  <link rel="shortcut icon" href="https://docs.mongodb.com/assets/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="Content-Type" content="text/html; charset={{ encoding }}" />
 


### PR DESCRIPTION
Switches favicon references to https://docs.mongodb.com/assets/favicon.ico