### PR TITLE
Revert "Update Ops Manager theme to remove duplicate EOL banner, but …

### DIFF
--- a/themes/mms-onprem/page.html
+++ b/themes/mms-onprem/page.html
@@ -54,11 +54,15 @@
   {%- endif %}
 
   {%- if theme_eol %}
-
-  {%- elif theme_eol_remove %}
+    <div class="alert alert-warning">
+      <span class="alert-message">{{theme_eol_msg}}</span>
+    </div>
+  {%- elif theme_active_branches and version not in theme_active_branches %}
     <div class="alert alert-info">
       <span class="alert-message">This version of the manual is no longer supported.</span>
+      {%- if theme_eol_remove %}
           <span class="alert-message">It will be removed on {{ theme_eol_date }}.</span>
+      {%- endif %}
     </div>
   {%- endif %}
 


### PR DESCRIPTION
…still allow info banner."

This reverts commit 8b7ba9cdf6048d567d4500be97aaa9a32f943c0f.

The original intention of this commit to remove the EOL banner is accomplished instead by adding theme options to mms-docs in: 