### PR TITLE
Attach 'docs' to version pathing

### DIFF
--- a/themes/mms-onprem/page.html
+++ b/themes/mms-onprem/page.html
@@ -96,7 +96,7 @@
         {% for v in theme_version_selector %}
           {% if not v.current %}
           <li>
-            <a href="#" data-path="{{ v.path }}" class="is-on-prem mms-version-selector">
+            <a href="#" data-path="{{ 'docs/' + v.path }}" class="is-on-prem mms-version-selector">
             {{ v.text }}
             </a>
           </li>

--- a/themes/mongodb/layout.html
+++ b/themes/mongodb/layout.html
@@ -30,7 +30,7 @@
             {% else %}
             <li>
             {% endif %}
-              <a {% if not v.current %}class="version-selector" {% endif %}href="#" data-path="{{ v.path }}">
+              <a {% if not v.current %}class="version-selector" {% endif %}href="#" data-path="{{ 'docs/' + v.path }}">
                 {% if v.text is defined %}{% set version_num = v.text.split()[0] %}{% endif %}
                 {% if (version_num is defined) and (version_num|int != 0) %}Version {% endif %}{{ v.text }}
               </a>


### PR DESCRIPTION
Proposed naive fix for legacy version selector.
Potentially fixes observed behavior at https://www.mongodb.com/docs/kubernetes-operator/stable/