### PR TITLE
Revert "Bump pygments from 2.4.2 to 2.7.4 in /giza"

### DIFF
--- a/giza/requirements.txt
+++ b/giza/requirements.txt
@@ -26,7 +26,7 @@ packaging==19.0
 pbr==5.3.1
 polib==1.1.0
 pycparser==2.19
-Pygments==2.7.4
+Pygments==2.4.2
 PyJWT==1.7.1
 pyparsing==2.4.0
 python-dateutil==2.8.0


### PR DESCRIPTION
Reverts mongodb/docs-tools#493