### PR TITLE
(DOCSP-23690) Warn users that OM 4.4 and 5.0 will soon be EOL

### DIFF
--- a/themes/mms-onprem/page.html
+++ b/themes/mms-onprem/page.html
@@ -69,6 +69,21 @@
     </div>
   {%- endif %}
 
+  {%- if theme_4-4_eol %}
+    <div class="alert alert-info alert-dismissible fade in" role="alert" style="margin-left: 20px">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <span class="alert-message">
+        <h4 class="alert-heading" style="margin-bottom: 10px;">
+          Support for Ops Manager 4.4 Ends July, 2022.
+        </h4>
+
+        <a href="{{theme_base_url}}/v5.0/tutorial/upgrade-ops-manager/">Upgrade Ops Manager to version 5.0</a> for continued support.
+      </span>
+    </div>
+  {%- endif %}
+
 {%- endblock -%}
 
 

--- a/themes/mms-onprem/page.html
+++ b/themes/mms-onprem/page.html
@@ -84,6 +84,21 @@
     </div>
   {%- endif %}
 
+  {%- if theme_5-0_eol %}
+  <div class="alert alert-info alert-dismissible fade in" role="alert" style="margin-left: 20px">
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+      <span aria-hidden="true">&times;</span>
+    </button>
+    <span class="alert-message">
+      <h4 class="alert-heading" style="margin-bottom: 10px;">
+        Support for Ops Manager 5.0 Ends July, 2023.
+      </h4>
+
+      <a href="{{theme_base_url}}/v6.0/tutorial/upgrade-ops-manager/">Upgrade Ops Manager to version 6.0</a> for continued support.
+    </span>
+  </div>
+{%- endif %}
+
 {%- endblock -%}
 
 

--- a/themes/mms-onprem/theme.conf
+++ b/themes/mms-onprem/theme.conf
@@ -17,3 +17,5 @@ nav_excluded = NAV
 eol_date = EOL_DATE
 eol_remove = EOL_REMOVE
 base_url = https://www.mongodb.com/docs
+5-0_eol =
+4-4_eol =


### PR DESCRIPTION
OM 4.4 will be EOL later this month. 5.0 will be EOL in July 2023, but engineering has asked that we have a banner for it now/soon.

This PR adds an "EOL soon" banner for both 4.4 and 5.0. Only the 4.4 banner will be activated now (via a separate PR on the mms-docs repo). The 5.0 banner will be activated once 6.0 is GA, at which time we will also activate the existing  "theme_eol_remove" banner for 4.4 if the last release has gone out.

Text was approved by the PM (Evin Roesle) via Slack.