### PR TITLE
(DOCSP-23865): Update legacy version flipper for 6.0 GA

### DIFF
--- a/data/manual-published-branches.yaml
+++ b/data/manual-published-branches.yaml
@@ -1,24 +1,21 @@
 version:
   published:
-    - '6.0 (upcoming)'
-    - 'Atlas Rapid Release (v5.3)'
+    - '6.0 (current)'
     - '5.0'
     - '4.4'
     - '4.2'
   active:
     - '6.0'
-    - '5.3'
     - '5.0'
     - '4.4'
     - '4.2'
-  stable: '5.0'
-  upcoming: '6.0'
+  stable: '6.0'
+  upcoming: null
 git:
   branches:
-    manual: 'v5.0'
+    manual: 'master'
     published:
       - 'master'
-      - 'v5.3'
       - 'v5.0'
       - 'v4.4'
       - 'v4.2'


### PR DESCRIPTION
6.0 is now "current". Additionally, we are unpublishing the 5.3 branch.