### PR TITLE
add new versions of php, ruby, and mongoid

### DIFF
--- a/data/mongoid-published-branches.yaml
+++ b/data/mongoid-published-branches.yaml
@@ -1,6 +1,7 @@
 version:
   published:
     - 'master'
+    - '8.0'
     - '7.4'
     - '7.3'
     - '7.2'
@@ -11,13 +12,14 @@ version:
     - '6.2'
     - '6.1'
     - '5.4'
-  stable: '7.4'
+  stable: '8.0'
   upcoming: master
 git:
   branches:
     manual: 'master'
     published:
       - 'master'
+      - '8.0'
       - '7.4'
       - '7.3'
       - '7.2'

--- a/data/php-library-published-branches.yaml
+++ b/data/php-library-published-branches.yaml
@@ -1,6 +1,7 @@
 version:
   published:
     - 'master'
+    - '1.13'
     - '1.12'
     - '1.11'
     - '1.10'
@@ -15,6 +16,7 @@ version:
     - '1.1'
   active:
     - 'master'
+    - '1.13'
     - '1.12'
     - '1.11'
     - '1.10'
@@ -27,13 +29,14 @@ version:
     - '1.3'
     - '1.2'
     - '1.1'
-  stable: '1.12'
+  stable: '1.13'
   upcoming: 'master'
 git:
   branches:
-    manual: 'v1.12'
+    manual: 'v1.13'
     published:
       - 'master'
+      - 'v1.13'
       - 'v1.12'
       - 'v1.11'
       - 'v1.10'

--- a/data/ruby-driver-published-branches.yaml
+++ b/data/ruby-driver-published-branches.yaml
@@ -1,6 +1,7 @@
 version:
   published:
     - 'master'
+    - '2.18'
     - '2.17'
     - '2.16'
     - '2.15'
@@ -21,6 +22,7 @@ version:
     - '1.x'
   active:
     - 'master'
+    - '2.18'
     - '2.17'
     - '2.16'
     - '2.15'
@@ -38,13 +40,14 @@ version:
     - '2.3'
     - '2.2'
     - '2.0'
-  stable: '2.17'
+  stable: '2.18'
   upcoming: master
 git:
   branches:
     manual: 'master'
     published:
       - 'master'
+      - 'v2.18'
       - 'v2.17'
       - 'v2.16'
       - 'v2.15'


### PR DESCRIPTION
This adds new versions to the drop-down selector for ruby, PHP, and mongoid.