### PR TITLE
Sunset MEKO 1.11, 1.12, 1.13

### DIFF
--- a/data/kubernetes-operator-published-branches.yaml
+++ b/data/kubernetes-operator-published-branches.yaml
@@ -4,17 +4,13 @@ version:
     - '1.16'
     - '1.15'
     - '1.14'
-    - '1.13'
-    - '1.12'
-    - '1.11'
+
   active:
     - '1.17'
     - '1.16'
     - '1.15'
     - '1.14'
-    - '1.13'
-    - '1.12'
-    - '1.11'
+
   stable: '1.16'
   upcoming: '1.17'
 git:
@@ -25,9 +21,7 @@ git:
       - 'v1.16'
       - 'v1.15'
       - 'v1.14'
-      - 'v1.13'
-      - 'v1.12'
-      - 'v1.11'
+
       # the branches/published list **must** be ordered from most to
       # least recent release.
 ...


### PR DESCRIPTION
[DOCSP-22196](https://jira.mongodb.org/browse/DOCSP-22196)

Changes:
Removed MEKO 1.11, 1.12, and 1.13 based on the [EOL dates](https://www.mongodb.com/docs/kubernetes-operator/master/reference/support-lifecycle/#k8s-support-lifecycle).
Used these [instructions](https://wiki.corp.mongodb.com/display/DE/How+To%3A+Sunset+a+Version+of+Documentation/) for sunsetting docs that use legacy builds.