### PR TITLE
Update urllib3 dependency version

### DIFF
--- a/giza/requirements.txt
+++ b/giza/requirements.txt
@@ -43,5 +43,5 @@ sphinx-intl==1.0.0
 sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-websupport==1.1.2
 typing==3.7.4
-urllib3==1.26.5
+urllib3==1.25.2
 Wand==0.5.4


### PR DESCRIPTION
Installing requirements as suggested in the docs leads to the following error:
> requests 2.22.0 requires urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1, but you'll have urllib3 1.26.5 which is incompatible.

Downgrading the urllib3 dependency in this file fixes the error and allows docs builds again.