### PR TITLE
DOP-3241: Include canonical links for EOL properties, remove noindex,nofollow meta tags

### DIFF
--- a/themes/mongodb/layout.html
+++ b/themes/mongodb/layout.html
@@ -132,14 +132,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="Content-Type" content="text/html; charset={{ encoding }}" />
 
-  {%- if version == theme_upcoming or theme_eol == "true" or theme_eol %}
-    <meta name="robots" content="noindex,nofollow" />
-  {%- elif version in theme_active_branches or not theme_active_branches %}
-    <meta name="robots" content="index" />
-    {%- block canonicalref %}{%- endblock -%}
-  {%- else -%}
-    <meta name="robots" content="noindex,nofollow" />
-  {%- endif %}
+  {%- block canonicalref %}{%- endblock -%}
 
   <meta name="release" content="{{release}}"/>
   <meta name="version" content="{{version}}"/>

--- a/themes/mongodb/layout.html
+++ b/themes/mongodb/layout.html
@@ -132,7 +132,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="Content-Type" content="text/html; charset={{ encoding }}" />
 
-  {%- block canonicalref %}{%- endblock -%}
+  {%- if version == theme_upcoming or theme_eol == "true" or theme_eol %}
+    {%- block canonicalref %}{%- endblock -%}
+  {%- endif %}
 
   <meta name="release" content="{{release}}"/>
   <meta name="version" content="{{version}}"/>


### PR DESCRIPTION
This PR uses the existing canonical link block only for, but for all, EOL'd properties.

* Manual v4.0: `<link rel="canonical" href="https://www.mongodb.com/docs/manual/" />`
* Ops Manger v4.0: `<link rel="canonical" href="https://www.mongodb.com/docs/ops-manager/current/" />`
* Ops Manger master: no `<link>` tag
* K8s Connector master: no `<link>` tag
* K8s Connector v1.1: `<link rel="canonical" href="https://www.mongodb.com/docs/kubernetes-operator/master/" />`