### PR TITLE
change current to stable in kubernetes page theme

### DIFF
--- a/themes/kubernetes-operator/page.html
+++ b/themes/kubernetes-operator/page.html
@@ -14,9 +14,9 @@
 
 {%- block canonicalref %}
   {%- if pagename == 'index' %}
-    <link rel="canonical" href="{{theme_base_url}}/{{theme_project}}/current/" />
+    <link rel="canonical" href="{{theme_base_url}}/{{theme_project}}/stable/" />
   {%- else %}
-    <link rel="canonical" href="{{theme_base_url}}/{{theme_project}}/current/{{pagename}}/" />
+    <link rel="canonical" href="{{theme_base_url}}/{{theme_project}}/stable/{{pagename}}/" />
   {%- endif -%}
 {%- endblock -%}
 


### PR DESCRIPTION
The canonical references for the kubernetes pages were changed from `master` to `current`. We've never used `current` for this docs set, but we use `stable`.  We've received reports from the SEO team that google is trying to crawl /current/*, so we should probably fix this.

Updating this in the theme.