### PR TITLE
(DOCSP-28448) [OM/CM] Managed Sharded Collection EOL banner

### DIFF
--- a/themes/mms-cloud/page.html
+++ b/themes/mms-cloud/page.html
@@ -90,6 +90,23 @@
       </span>
     </div>
   {%- endif %}
+
+  {%- if theme_managed_sharded_collection_eol %}
+    <div class="alert alert-info alert-dismissible fade in" role="alert" style="margin-left: 20px">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <span class="alert-message">
+        <h4 class="alert-heading" style="margin-bottom: 10px;">
+          On June 16th, 2023, MongoDB Cloud Manager will end support for SNMP and 
+          the Manage Sharded Collections UI.
+        
+          The removal of the Manage Sharded Collections UI will not impact your sharded clusters.
+        </h4>
+      </span>
+    </div>
+  {%- endif %}
+
 {%- endblock -%}
 
 {% block language_selector %}{% endblock %}

--- a/themes/mms-cloud/theme.conf
+++ b/themes/mms-cloud/theme.conf
@@ -16,4 +16,5 @@ edition = EDITION
 nav_excluded = NAV
 automation_eol =
 backup_monitoring_eol_past =
+managed_sharded_collection_eol = 
 base_url = https://www.mongodb.com/docs

--- a/themes/mms-onprem/page.html
+++ b/themes/mms-onprem/page.html
@@ -87,19 +87,35 @@
   {%- endif %}
 
   {%- if theme_5_0_eol %}
-  <div class="alert alert-info alert-dismissible fade in" role="alert" style="margin-left: 20px">
-    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-      <span aria-hidden="true">&times;</span>
-    </button>
-    <span class="alert-message">
-      <h4 class="alert-heading" style="margin-bottom: 10px;">
-        Support for Ops Manager 5.0 Ends July 2023.
-      </h4>
+    <div class="alert alert-info alert-dismissible fade in" role="alert" style="margin-left: 20px">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <span class="alert-message">
+        <h4 class="alert-heading" style="margin-bottom: 10px;">
+          Support for Ops Manager 5.0 Ends July 2023.
+        </h4>
+  
+        <a href="{{theme_base_url}}/ops-manager/v6.0/tutorial/upgrade-ops-manager/">Upgrade Ops Manager to version 6.0</a> for continued support.
+      </span>
+    </div>
+  {%- endif %}
 
-      <a href="{{theme_base_url}}/ops-manager/v6.0/tutorial/upgrade-ops-manager/">Upgrade Ops Manager to version 6.0</a> for continued support.
-    </span>
-  </div>
-{%- endif %}
+  {%- if theme_managed_sharded_collection_eol %}
+    <div class="alert alert-info alert-dismissible fade in" role="alert" style="margin-left: 20px">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <span class="alert-message">
+        <h4 class="alert-heading" style="margin-bottom: 10px;">
+          In version 7.0, MongoDB Ops Manager will end support for SNMP and 
+          the Manage Sharded Collections UI.
+        
+          The removal of the Manage Sharded Collections UI will not impact your sharded clusters.
+        </h4>
+      </span>
+    </div>
+  {%- endif %}
 
 {%- endblock -%}
 

--- a/themes/mms-onprem/theme.conf
+++ b/themes/mms-onprem/theme.conf
@@ -17,6 +17,7 @@ nav_excluded = NAV
 eol_date = EOL_DATE
 eol_remove = EOL_REMOVE
 backup_monitoring_eol_past =
+managed_sharded_collection_eol = 
 base_url = https://www.mongodb.com/docs
 5_0_eol =
 4_4_eol =


### PR DESCRIPTION
[Jira](https://jira.mongodb.org/browse/DOCSP-28448)

Will be staged with mms-docs, but this part has to be merged into docs-tools first

Using [this wiki](https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=149195138)

Rephrased the copy from the ticket
> CM docs message - 
"On June 16h, 2023, we will be ending SNMP and Manage Sharded Collections UI support for MongoDB in Cloud Manager. We will remove these features from the UI completely, at a later date. The removal of Manage Sharded Collections UI does not cause any impact to your sharded clusters."
OM docs message -
"In Ops Manager 7.0, we will be removing SNMP and Manage Sharded Collections UI support for MongoDB in Ops Manager. The removal of Manage Sharded Collections UI does not cause any impact to your sharded clusters."