### PR TITLE
(DOCSP-31800): Move OM 5.0 docs to the legacy site

### DIFF
--- a/data/mms-published-branches.yaml
+++ b/data/mms-published-branches.yaml
@@ -2,11 +2,9 @@ version:
   published:
     - 'upcoming'
     - '6.0'
-    - '5.0'
   active:
     - 'upcoming'
     - '6.0'
-    - '5.0'
   stable: '6.0'
   upcoming: '7.0'
 git:
@@ -15,7 +13,6 @@ git:
     published:
       - 'master'
       - 'v6.0'
-      - 'v5.0'
       # the branches/published list **must** be ordered from most to
       # least recent release.
 ...


### PR DESCRIPTION
Updates docs-tools based on legacy instructions from [the wiki](https://wiki.corp.mongodb.com/display/DE/How+To%3A+Sunset+an+EOL+Version+of+Documentation#HowTo:SunsetanEOLVersionofDocumentation-LegacyInstructions).
[Jira](https://jira.mongodb.org/browse/DOCSP-31800)