### PR TITLE
(DOCSP-34603) Updates OM upcoming to v7.0 branch

### DIFF
--- a/data/mms-published-branches.yaml
+++ b/data/mms-published-branches.yaml
@@ -11,7 +11,7 @@ git:
   branches:
     manual: 'v6.0'
     published:
-      - 'master'
+      - 'v7.0'
       - 'v6.0'
       # the branches/published list **must** be ordered from most to
       # least recent release.


### PR DESCRIPTION
We want the v7.0 branch of mms-docs to display when a user selects "Upcoming" in the docs. "master" branch content will soon be limited to CM content only in preparation for the OM/CM migration to Snooty.